### PR TITLE
Enable Feature for KIAM Role based policy for Authorization

### DIFF
--- a/clientlibrary/config/config.go
+++ b/clientlibrary/config/config.go
@@ -157,6 +157,7 @@ type (
 	KinesisClientLibConfiguration struct {
 		// ApplicationName is name of application. Kinesis allows multiple applications to consume the same stream.
 		ApplicationName string
+		
 
 		// DynamoDBEndpoint is an optional endpoint URL that overrides the default generated endpoint for a DynamoDB client.
 		// If this is empty, the default generated endpoint will be used.
@@ -171,6 +172,12 @@ type (
 
 		// StreamName is the name of Kinesis stream
 		StreamName string
+
+		// KinesisIAMRoleArn is the IAM Role to access Kinesis stream
+		KinesisIAMRoleArn string
+	
+		// DynamodbIAMRoleArn is the IAM Role to access dynamodb stream
+		DynamodbIAMRoleArn string
 
 		// WorkerID used to distinguish different workers/processes of a Kinesis application
 		WorkerID string

--- a/clientlibrary/config/config.go
+++ b/clientlibrary/config/config.go
@@ -157,7 +157,6 @@ type (
 	KinesisClientLibConfiguration struct {
 		// ApplicationName is name of application. Kinesis allows multiple applications to consume the same stream.
 		ApplicationName string
-		
 
 		// DynamoDBEndpoint is an optional endpoint URL that overrides the default generated endpoint for a DynamoDB client.
 		// If this is empty, the default generated endpoint will be used.
@@ -173,11 +172,8 @@ type (
 		// StreamName is the name of Kinesis stream
 		StreamName string
 
-		// KinesisIAMRoleArn is the IAM Role to access Kinesis stream
-		KinesisIAMRoleArn string
-	
-		// DynamodbIAMRoleArn is the IAM Role to access dynamodb stream
-		DynamodbIAMRoleArn string
+		// KclAMRoleArn is the IAM Role to use KCL
+		KclIAMRoleArn string
 
 		// WorkerID used to distinguish different workers/processes of a Kinesis application
 		WorkerID string

--- a/clientlibrary/config/config_test.go
+++ b/clientlibrary/config/config_test.go
@@ -33,8 +33,12 @@ func TestConfig(t *testing.T) {
 		WithCallProcessRecordsEvenForEmptyRecordList(true).
 		WithTaskBackoffTimeMillis(10).
 		WithMetricsBufferTimeMillis(500).
-		WithMetricsMaxQueueSize(200)
+		WithMetricsMaxQueueSize(200).
+		WithKinesisIAMRoleArn("arn:aws:iam::333333333333:role/KinesisRole").
+		WithDynamodbIAMRoleArn("arn:aws:iam::333333333333:role/DynamoDBRole")
 
 	assert.Equal(t, "appName", kclConfig.ApplicationName)
 	assert.Equal(t, 500, kclConfig.FailoverTimeMillis)
+	assert.Equal(t, "arn:aws:iam::333333333333:role/DynamoDBRole", kclConfig.DynamodbIAMRoleArn)
+	assert.Equal(t, "arn:aws:iam::333333333333:role/KinesisRole", kclConfig.KinesisIAMRoleArn)
 }

--- a/clientlibrary/config/config_test.go
+++ b/clientlibrary/config/config_test.go
@@ -34,11 +34,9 @@ func TestConfig(t *testing.T) {
 		WithTaskBackoffTimeMillis(10).
 		WithMetricsBufferTimeMillis(500).
 		WithMetricsMaxQueueSize(200).
-		WithKinesisIAMRoleArn("arn:aws:iam::333333333333:role/KinesisRole").
-		WithDynamodbIAMRoleArn("arn:aws:iam::333333333333:role/DynamoDBRole")
+		WithKclIAMRoleArn("arn:aws:iam::333333333333:role/KinesisRole")
 
 	assert.Equal(t, "appName", kclConfig.ApplicationName)
 	assert.Equal(t, 500, kclConfig.FailoverTimeMillis)
-	assert.Equal(t, "arn:aws:iam::333333333333:role/DynamoDBRole", kclConfig.DynamodbIAMRoleArn)
-	assert.Equal(t, "arn:aws:iam::333333333333:role/KinesisRole", kclConfig.KinesisIAMRoleArn)
+	assert.Equal(t, "arn:aws:iam::333333333333:role/KinesisRole", kclConfig.KclIAMRoleArn)
 }

--- a/clientlibrary/config/kcl-config.go
+++ b/clientlibrary/config/kcl-config.go
@@ -185,17 +185,9 @@ func (c *KinesisClientLibConfiguration) WithMetricsMaxQueueSize(metricsMaxQueueS
 	return c
 }
 
-// WithKinesisIAMRoleArn configures Kinesis IAM Role ARN
-func (c *KinesisClientLibConfiguration) WithKinesisIAMRoleArn(kinesisIAMRoleArn string) *KinesisClientLibConfiguration {
-	checkIsValueNotEmpty("KinesisIAMRoleArn", kinesisIAMRoleArn)
-	c.KinesisIAMRoleArn = kinesisIAMRoleArn
+// WithKclIAMRoleArn configures KCL IAM Role ARN
+func (c *KinesisClientLibConfiguration) WithKclIAMRoleArn(kclIAMRoleArn string) *KinesisClientLibConfiguration {
+	checkIsValueNotEmpty("KclIAMRoleArn", kclIAMRoleArn)
+	c.KclIAMRoleArn = kclIAMRoleArn
 	return c
 }
-
-// WithDynamodbIAMRoleArn configures Dynamodb IAM Role ARN
-func (c *KinesisClientLibConfiguration) WithDynamodbIAMRoleArn(dynamodbIAMRoleArn string) *KinesisClientLibConfiguration {
-	checkIsValueNotEmpty("DynamodbIAMRoleArn", dynamodbIAMRoleArn)
-	c.DynamodbIAMRoleArn = dynamodbIAMRoleArn
-	return c
-}
-

--- a/clientlibrary/config/kcl-config.go
+++ b/clientlibrary/config/kcl-config.go
@@ -184,3 +184,18 @@ func (c *KinesisClientLibConfiguration) WithMetricsMaxQueueSize(metricsMaxQueueS
 	c.MetricsMaxQueueSize = metricsMaxQueueSize
 	return c
 }
+
+// WithKinesisIAMRoleArn configures Kinesis IAM Role ARN
+func (c *KinesisClientLibConfiguration) WithKinesisIAMRoleArn(kinesisIAMRoleArn string) *KinesisClientLibConfiguration {
+	checkIsValueNotEmpty("KinesisIAMRoleArn", kinesisIAMRoleArn)
+	c.KinesisIAMRoleArn = kinesisIAMRoleArn
+	return c
+}
+
+// WithDynamodbIAMRoleArn configures Dynamodb IAM Role ARN
+func (c *KinesisClientLibConfiguration) WithDynamodbIAMRoleArn(dynamodbIAMRoleArn string) *KinesisClientLibConfiguration {
+	checkIsValueNotEmpty("DynamodbIAMRoleArn", dynamodbIAMRoleArn)
+	c.DynamodbIAMRoleArn = dynamodbIAMRoleArn
+	return c
+}
+

--- a/clientlibrary/metrics/interfaces.go
+++ b/clientlibrary/metrics/interfaces.go
@@ -35,6 +35,7 @@ import (
 type MonitoringConfiguration struct {
 	MonitoringService string // Type of monitoring to expose. Supported types are "prometheus"
 	Region            string
+	KclIAMRoleArn     string
 	Prometheus        PrometheusMonitoringService
 	CloudWatch        CloudWatchMonitoringService
 	service           MonitoringService
@@ -72,6 +73,7 @@ func (m *MonitoringConfiguration) Init(nameSpace, streamName string, workerID st
 		m.CloudWatch.KinesisStream = streamName
 		m.CloudWatch.WorkerID = workerID
 		m.CloudWatch.Region = m.Region
+		m.CloudWatch.KclIAMRoleArn = m.KclIAMRoleArn
 		m.service = &m.CloudWatch
 	default:
 		return fmt.Errorf("Invalid monitoring service type %s", m.MonitoringService)

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -81,11 +81,10 @@ func (ss *shardStatus) setLeaseOwner(owner string) {
  * the shards).
  */
 type Worker struct {
-	streamName         string
-	regionName         string
-	workerID           string
-	kinesisIAMRoleArn  string
-	dynamodbIAMRoleArn string
+	streamName    string
+	regionName    string
+	workerID      string
+	kclIAMRoleArn string
 
 	processorFactory kcl.IRecordProcessorFactory
 	kclConfig        *config.KinesisClientLibConfiguration
@@ -106,21 +105,20 @@ type Worker struct {
 // NewWorker constructs a Worker instance for processing Kinesis stream data.
 func NewWorker(factory kcl.IRecordProcessorFactory, kclConfig *config.KinesisClientLibConfiguration, metricsConfig *metrics.MonitoringConfiguration) *Worker {
 	w := &Worker{
-		streamName:         kclConfig.StreamName,
-		regionName:         kclConfig.RegionName,
-		workerID:           kclConfig.WorkerID,
-		processorFactory:   factory,
-		kclConfig:          kclConfig,
-		metricsConfig:      metricsConfig,
-		kinesisIAMRoleArn:  kclConfig.KinesisIAMRoleArn,
-		dynamodbIAMRoleArn: kclConfig.DynamodbIAMRoleArn,
+		streamName:       kclConfig.StreamName,
+		regionName:       kclConfig.RegionName,
+		workerID:         kclConfig.WorkerID,
+		processorFactory: factory,
+		kclConfig:        kclConfig,
+		metricsConfig:    metricsConfig,
+		kclIAMRoleArn:    kclConfig.KclIAMRoleArn,
 	}
 
 	log.Info("Creating Kinesis session")
-	if len(w.kinesisIAMRoleArn) > 0 {
+	if len(w.kclIAMRoleArn) > 0 {
 		// create session for Kinesis
 		s := session.Must(session.NewSession())
-		creds := stscreds.NewCredentials(s, w.kinesisIAMRoleArn)
+		creds := stscreds.NewCredentials(s, w.kclIAMRoleArn)
 		w.kc = kinesis.New(s, &aws.Config{Credentials: creds, Region: aws.String(w.regionName),
 			Endpoint: &kclConfig.KinesisEndpoint})
 	} else {
@@ -133,13 +131,13 @@ func NewWorker(factory kcl.IRecordProcessorFactory, kclConfig *config.KinesisCli
 		w.kc = kinesis.New(s)
 	}
 	log.Info("Creating DynamoDB session")
-	if len(w.dynamodbIAMRoleArn) > 0 {
+	if len(w.kclIAMRoleArn) > 0 {
 		// create session for Dynamodb
 		s := session.Must(session.NewSession())
-		creds := stscreds.NewCredentials(s, w.dynamodbIAMRoleArn)
+		creds := stscreds.NewCredentials(s, w.kclIAMRoleArn)
 		w.dynamo = dynamodb.New(s, &aws.Config{Credentials: creds, Region: aws.String(w.regionName),
 			Endpoint: &kclConfig.DynamoDBEndpoint})
-		log.Info(w.dynamodbIAMRoleArn)
+		log.Info(w.kclIAMRoleArn)
 	} else {
 		s := session.New(&aws.Config{
 			Region:   aws.String(w.regionName),
@@ -150,7 +148,7 @@ func NewWorker(factory kcl.IRecordProcessorFactory, kclConfig *config.KinesisCli
 	w.checkpointer = NewDynamoCheckpoint(w.dynamo, kclConfig)
 
 	if w.metricsConfig == nil {
-		w.metricsConfig = &metrics.MonitoringConfiguration{MonitoringService: ""}
+		w.metricsConfig = &metrics.MonitoringConfiguration{MonitoringService: "", KclIAMRoleArn: w.kclIAMRoleArn}
 	}
 	return w
 }

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -38,6 +38,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
@@ -80,9 +81,11 @@ func (ss *shardStatus) setLeaseOwner(owner string) {
  * the shards).
  */
 type Worker struct {
-	streamName string
-	regionName string
-	workerID   string
+	streamName         string
+	regionName         string
+	workerID           string
+	kinesisIAMRoleArn  string
+	dynamodbIAMRoleArn string
 
 	processorFactory kcl.IRecordProcessorFactory
 	kclConfig        *config.KinesisClientLibConfiguration
@@ -103,28 +106,47 @@ type Worker struct {
 // NewWorker constructs a Worker instance for processing Kinesis stream data.
 func NewWorker(factory kcl.IRecordProcessorFactory, kclConfig *config.KinesisClientLibConfiguration, metricsConfig *metrics.MonitoringConfiguration) *Worker {
 	w := &Worker{
-		streamName:       kclConfig.StreamName,
-		regionName:       kclConfig.RegionName,
-		workerID:         kclConfig.WorkerID,
-		processorFactory: factory,
-		kclConfig:        kclConfig,
-		metricsConfig:    metricsConfig,
+		streamName:         kclConfig.StreamName,
+		regionName:         kclConfig.RegionName,
+		workerID:           kclConfig.WorkerID,
+		processorFactory:   factory,
+		kclConfig:          kclConfig,
+		metricsConfig:      metricsConfig,
+		kinesisIAMRoleArn:  kclConfig.KinesisIAMRoleArn,
+		dynamodbIAMRoleArn: kclConfig.DynamodbIAMRoleArn,
 	}
 
-	// create session for Kinesis
 	log.Info("Creating Kinesis session")
-	s := session.New(&aws.Config{
-		Region:   aws.String(w.regionName),
-		Endpoint: &kclConfig.KinesisEndpoint,
-	})
-	w.kc = kinesis.New(s)
+	if len(w.kinesisIAMRoleArn) > 0 {
+		// create session for Kinesis
+		s := session.Must(session.NewSession())
+		creds := stscreds.NewCredentials(s, w.kinesisIAMRoleArn)
+		w.kc = kinesis.New(s, &aws.Config{Credentials: creds, Region: aws.String(w.regionName),
+			Endpoint: &kclConfig.KinesisEndpoint})
+	} else {
 
+		// create session for Kinesis
+		s := session.New(&aws.Config{
+			Region:   aws.String(w.regionName),
+			Endpoint: &kclConfig.KinesisEndpoint,
+		})
+		w.kc = kinesis.New(s)
+	}
 	log.Info("Creating DynamoDB session")
-	s = session.New(&aws.Config{
-		Region:   aws.String(w.regionName),
-		Endpoint: &kclConfig.DynamoDBEndpoint,
-	})
-	w.dynamo = dynamodb.New(s)
+	if len(w.dynamodbIAMRoleArn) > 0 {
+		// create session for Dynamodb
+		s := session.Must(session.NewSession())
+		creds := stscreds.NewCredentials(s, w.dynamodbIAMRoleArn)
+		w.dynamo = dynamodb.New(s, &aws.Config{Credentials: creds, Region: aws.String(w.regionName),
+			Endpoint: &kclConfig.DynamoDBEndpoint})
+		log.Info(w.dynamodbIAMRoleArn)
+	} else {
+		s := session.New(&aws.Config{
+			Region:   aws.String(w.regionName),
+			Endpoint: &kclConfig.DynamoDBEndpoint,
+		})
+		w.dynamo = dynamodb.New(s)
+	}
 	w.checkpointer = NewDynamoCheckpoint(w.dynamo, kclConfig)
 
 	if w.metricsConfig == nil {


### PR DESCRIPTION
Enable Feature for KIAM Role based policy for Authorization. The Role provided should contain appropriate policies to access Kinesis/Dynamodb/Cloudwatch. This is an alternate to using actual credentials (rather an option to use temp credentials by using IAM roles)
