### PR TITLE
Add credential configuration for resources

### DIFF
--- a/clientlibrary/config/config.go
+++ b/clientlibrary/config/config.go
@@ -40,6 +40,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	creds "github.com/aws/aws-sdk-go/aws/credentials"
 )
 
 const (
@@ -165,6 +166,15 @@ type (
 		// KinesisEndpoint is an optional endpoint URL that overrides the default generated endpoint for a Kinesis client.
 		// If this is empty, the default generated endpoint will be used.
 		KinesisEndpoint string
+
+		// KinesisCredentials is used to access Kinesis
+		KinesisCredentials *creds.Credentials
+
+		// DynamoDBCredentials is used to access DynamoDB
+		DynamoDBCredentials *creds.Credentials
+
+		// CloudWatchCredentials is used to access CloudWatch
+		CloudWatchCredentials *creds.Credentials
 
 		// TableName is name of the dynamo db table for managing kinesis stream default to ApplicationName
 		TableName string

--- a/clientlibrary/config/kcl-config.go
+++ b/clientlibrary/config/kcl-config.go
@@ -34,6 +34,7 @@
 package config
 
 import (
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"time"
 
 	"github.com/vmware/vmware-go-kcl/clientlibrary/utils"
@@ -41,6 +42,19 @@ import (
 
 // NewKinesisClientLibConfig to create a default KinesisClientLibConfiguration based on the required fields.
 func NewKinesisClientLibConfig(applicationName, streamName, regionName, workerID string) *KinesisClientLibConfiguration {
+	return NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regionName, workerID,
+		nil, nil, nil)
+}
+
+// NewKinesisClientLibConfig to create a default KinesisClientLibConfiguration based on the required fields.
+func NewKinesisClientLibConfigWithCredential(applicationName, streamName, regionName, workerID string,
+	creds *credentials.Credentials) *KinesisClientLibConfiguration {
+	return NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regionName, workerID, creds, creds, creds)
+}
+
+// NewKinesisClientLibConfig to create a default KinesisClientLibConfiguration based on the required fields.
+func NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regionName, workerID string,
+	kiniesisCreds, dynamodbCreds, cloudwatchCreds *credentials.Credentials) *KinesisClientLibConfiguration {
 	checkIsValueNotEmpty("ApplicationName", applicationName)
 	checkIsValueNotEmpty("StreamName", streamName)
 	checkIsValueNotEmpty("RegionName", regionName)
@@ -52,6 +66,9 @@ func NewKinesisClientLibConfig(applicationName, streamName, regionName, workerID
 	// populate the KCL configuration with default values
 	return &KinesisClientLibConfiguration{
 		ApplicationName:                                  applicationName,
+		KinesisCredentials:                               kiniesisCreds,
+		DynamoDBCredentials:                              dynamodbCreds,
+		CloudWatchCredentials:                            cloudwatchCreds,
 		TableName:                                        applicationName,
 		StreamName:                                       streamName,
 		RegionName:                                       regionName,


### PR DESCRIPTION
Add credentials for Kinesis, DynamoDB and Cloudwatch. See the worker_test.go
to see how to use it.

Signed-off-by: Tao Jiang <taoj@vmware.com>