### PR TITLE
Removing signal handling from event loop

### DIFF
--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -29,10 +29,7 @@ package worker
 
 import (
 	"errors"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -67,7 +64,6 @@ type Worker struct {
 
 	stop      *chan struct{}
 	waitGroup *sync.WaitGroup
-	sigs      *chan os.Signal
 
 	shardStatus map[string]*par.ShardStatus
 
@@ -185,10 +181,6 @@ func (w *Worker) initialize() error {
 
 	w.shardStatus = make(map[string]*par.ShardStatus)
 
-	sigs := make(chan os.Signal, 1)
-	w.sigs = &sigs
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
 	stopChan := make(chan struct{})
 	w.stop = &stopChan
 
@@ -282,10 +274,6 @@ func (w *Worker) eventLoop() {
 		}
 
 		select {
-		case sig := <-*w.sigs:
-			log.Infof("Received signal %s. Exiting", sig)
-			w.Shutdown()
-			return
 		case <-*w.stop:
 			log.Info("Shutting down")
 			return


### PR DESCRIPTION
Because the worker event loop listens for signals, it is difficult for a
user of the library to call worker.Shutdown() on signal input as this
results in a panic from Shutdown being called twice. One can avoid the
panic by not calling Shutdown and letting the library handle it but then
it becomes hard to know when the program should exit and requires the
addition of a time.Sleep.

Letting the user of the library control what happens on signal input
give a greater level of flexibility.

Signed-off-by: Ivan Antolic-Soban <ivan.soban@gmail.com>