### PR TITLE
Namespacing the checkpointer keys by stream name

### DIFF
--- a/clientlibrary/partition/partition.go
+++ b/clientlibrary/partition/partition.go
@@ -35,6 +35,7 @@ import (
 type ShardStatus struct {
 	ID            string
 	ParentShardId string
+	StreamName    string
 	Checkpoint    string
 	AssignedTo    string
 	Mux           *sync.Mutex
@@ -55,4 +56,8 @@ func (ss *ShardStatus) SetLeaseOwner(owner string) {
 	ss.Mux.Lock()
 	defer ss.Mux.Unlock()
 	ss.AssignedTo = owner
+}
+
+func (ss *ShardStatus) GetLeaseID() string {
+	return ss.StreamName + "/" + ss.ID
 }

--- a/clientlibrary/worker/shard-consumer.go
+++ b/clientlibrary/worker/shard-consumer.go
@@ -263,8 +263,9 @@ func (sc *ShardConsumer) waitOnParentShard(shard *par.ShardStatus) error {
 	}
 
 	pshard := &par.ShardStatus{
-		ID:  shard.ParentShardId,
-		Mux: &sync.Mutex{},
+		ID:         shard.ParentShardId,
+		StreamName: shard.StreamName,
+		Mux:        &sync.Mutex{},
 	}
 
 	for {

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -328,6 +328,7 @@ func (w *Worker) getShardIDs(startShardID string, shardInfo map[string]bool) err
 			w.shardStatus[*s.ShardId] = &par.ShardStatus{
 				ID:                     *s.ShardId,
 				ParentShardId:          aws.StringValue(s.ParentShardId),
+				StreamName:             w.streamName,
 				Mux:                    &sync.Mutex{},
 				StartingSequenceNumber: aws.StringValue(s.SequenceNumberRange.StartingSequenceNumber),
 				EndingSequenceNumber:   aws.StringValue(s.SequenceNumberRange.EndingSequenceNumber),


### PR DESCRIPTION
The default limit in AWS on the number of DynamoDB tables is 256 and in
an effort to limit the number of tables created, it would be desirable
to allow the library to use the same DynamoDB table for N number of
workers. This requires namespacing the checkpointer table keys. We have
chosen to do this by creating the partition key for the checkpointer
table from both the stream name and the shard id.

Signed-off-by: Ivan Antolic-Soban <iantolic-soban@pindropsecurity.com>