### PR TITLE
Provide a New function which allows injecting custom AWS clients for dynamo and kinesis

### DIFF
--- a/clientlibrary/worker/worker-custom.go
+++ b/clientlibrary/worker/worker-custom.go
@@ -30,7 +30,7 @@ import (
 	"github.com/vmware/vmware-go-kcl/clientlibrary/metrics"
 )
 
-// NewCustomWorker constructs a Worker instance for processing Kinesis stream data by directly inject custom cjheckpointer.
+// NewCustomWorker constructs a Worker instance for processing Kinesis stream data by directly inject custom checkpointer.
 func NewCustomWorker(factory kcl.IRecordProcessorFactory, kclConfig *config.KinesisClientLibConfiguration,
 	checkpointer chk.Checkpointer, metricsConfig *metrics.MonitoringConfiguration) *Worker {
 	w := &Worker{


### PR DESCRIPTION
This change allows a user of the library to provide alternative interfaces for Kinesis and DynamoDB, therefore allowing a stub to be passed in for mocking in unit tests.