### PR TITLE
Release shard lease after shutdown

### DIFF
--- a/clientlibrary/checkpoint/checkpointer.go
+++ b/clientlibrary/checkpoint/checkpointer.go
@@ -48,11 +48,23 @@ const (
 
 // Checkpointer handles checkpointing when a record has been processed
 type Checkpointer interface {
+	// Init initialises the Checkpoint
 	Init() error
+
+	// GetLease attempts to gain a lock on the given shard
 	GetLease(*par.ShardStatus, string) error
+
+	// CheckpointSequence writes a checkpoint at the designated sequence ID
 	CheckpointSequence(*par.ShardStatus) error
+
+	// FetchCheckpoint retrieves the checkpoint for the given shard
 	FetchCheckpoint(*par.ShardStatus) error
+
+	// RemoveLeaseInfo to remove lease info for shard entry because the shard no longer exists
 	RemoveLeaseInfo(string) error
+
+	// RemoveLeaseOwner to remove lease owner for the shard entry to make the shard available for reassignment
+	RemoveLeaseOwner(string) error
 }
 
 // ErrSequenceIDNotFound is returned by FetchCheckpoint when no SequenceID is found

--- a/clientlibrary/worker/shard-consumer.go
+++ b/clientlibrary/worker/shard-consumer.go
@@ -285,6 +285,13 @@ func (sc *ShardConsumer) waitOnParentShard(shard *par.ShardStatus) error {
 func (sc *ShardConsumer) releaseLease(shard *par.ShardStatus) {
 	log.Infof("Release lease for shard %s", shard.ID)
 	shard.SetLeaseOwner("")
+
+	// Release the lease by wiping out the lease owner for the shard
+	// Note: we don't need to do anything in case of error here and shard lease will eventuall be expired.
+	if err := sc.checkpointer.RemoveLeaseOwner(shard.ID); err != nil {
+		log.Errorf("Failed to release shard lease or shard: %s Error: %+v", shard.ID, err)
+	}
+
 	// reporting lease lose metrics
 	sc.mService.LeaseLost(shard.ID)
 }

--- a/support/scripts/test.sh
+++ b/support/scripts/test.sh
@@ -2,4 +2,4 @@
 . support/scripts/functions.sh
 
 # Run only the unit tests and not integration tests
-go test -race $(local_go_pkgs)
+go test -cover -race $(local_go_pkgs)

--- a/test/worker_test.go
+++ b/test/worker_test.go
@@ -50,6 +50,8 @@ const (
 const specstr = `{"name":"kube-qQyhk","networking":{"containerNetworkCidr":"10.2.0.0/16"},"orgName":"BVT-Org-cLQch","projectName":"project-tDSJd","serviceLevel":"DEVELOPER","size":{"count":1},"version":"1.8.1-4"}`
 const metricsSystem = "cloudwatch"
 
+var shardID string
+
 func TestWorker(t *testing.T) {
 	kclConfig := cfg.NewKinesisClientLibConfig("appName", streamName, regionName, workerID).
 		WithInitialPositionInStream(cfg.LATEST).
@@ -235,6 +237,7 @@ type dumpRecordProcessor struct {
 
 func (dd *dumpRecordProcessor) Initialize(input *kc.InitializationInput) {
 	dd.t.Logf("Processing SharId: %v at checkpoint: %v", input.ShardId, aws.StringValue(input.ExtendedSequenceNumber.SequenceNumber))
+	shardID = input.ShardId
 }
 
 func (dd *dumpRecordProcessor) ProcessRecords(input *kc.ProcessRecordsInput) {


### PR DESCRIPTION
Currently, only local cached shard info has been removed when worker losts the
lease. The info inside checkpointer (dynamoDB) is not removed. This causes
lease has been hold until the lease expiration and it might take too long
for shard is ready for other worker to grab. This change release the lease
in checkpointer immediately.

The user need to ensure appropriate checkpointing before return from
Shutdown callback.

Test:
  updated unit test and integration test to ensure only the shard owner
has been wiped out and leave the checkpoint information intact.

Signed-off-by: Tao Jiang <taoj@vmware.com>