### PR TITLE
Get rid of unused skipTableCheck

### DIFF
--- a/clientlibrary/checkpoint/dynamodb-checkpointer.go
+++ b/clientlibrary/checkpoint/dynamodb-checkpointer.go
@@ -61,7 +61,6 @@ type DynamoCheckpoint struct {
 	svc            dynamodbiface.DynamoDBAPI
 	kclConfig      *config.KinesisClientLibConfiguration
 	Retries        int
-	skipTableCheck bool
 }
 
 func NewDynamoCheckpoint(kclConfig *config.KinesisClientLibConfiguration) *DynamoCheckpoint {
@@ -103,7 +102,7 @@ func (checkpointer *DynamoCheckpoint) Init() error {
 		checkpointer.svc = dynamodb.New(s)
 	}
 
-	if !checkpointer.skipTableCheck && !checkpointer.doesTableExist() {
+	if !checkpointer.doesTableExist() {
 		return checkpointer.createTable()
 	}
 	return nil


### PR DESCRIPTION
The skipTableCheck variable is supposed to be used by unit test only. It is originally created by https://github.com/patrobinson/gokini/blob/master/checkpointer_test.go

However, I think it is redundant because the mockDynamoDB has tableExist field already. On the other hand, the code does check the existence of a table and use it if it does exist. Also, creating a dynamodb table is cheap operation and it only need to do once during initialization. Therefore, there isn't any need to skip it.

Remove skipTableCheck to avoid confusion.

https://github.com/vmware/vmware-go-kcl/issues/38
