### PR TITLE
Fix missing init position with AT_TIMESTAMP

### DIFF
--- a/test/worker_test.go
+++ b/test/worker_test.go
@@ -81,6 +81,30 @@ func TestWorker(t *testing.T) {
 	runTest(kclConfig, false, t)
 }
 
+func TestWorkerWithTimestamp(t *testing.T) {
+	// In order to have precise control over logging. Use logger with config
+	config := logger.Configuration{
+		EnableConsole:     true,
+		ConsoleLevel:      logger.Debug,
+		ConsoleJSONFormat: false,
+	}
+	// Use logrus logger
+	log := logger.NewLogrusLoggerWithConfig(config)
+
+	ts := time.Now().Add(time.Second * 5)
+	kclConfig := cfg.NewKinesisClientLibConfig("appName", streamName, regionName, workerID).
+		WithTimestampAtInitialPositionInStream(&ts).
+		WithMaxRecords(10).
+		WithMaxLeasesForWorker(1).
+		WithShardSyncIntervalMillis(5000).
+		WithFailoverTimeMillis(300000).
+		WithMetricsBufferTimeMillis(10000).
+		WithMetricsMaxQueueSize(20).
+		WithLogger(log)
+
+	runTest(kclConfig, false, t)
+}
+
 func TestWorkerWithSigInt(t *testing.T) {
 	// At miminal. use standard zap logger
 	//zapLogger, err := zap.NewProduction()


### PR DESCRIPTION
AT_TIMESTAMP start from the record at or after the specified
server-side Timestamp. However, the implementation was
missing. The bug was not notices until recently because most
of users never use this feature.

Fixed https://github.com/vmware/vmware-go-kcl/issues/37

Signed-off-by: Tao Jiang <taoj@vmware.com>