### PR TITLE
logger: move zap into its own package

### DIFF
--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -21,41 +21,10 @@
 package logger
 
 import (
-	"github.com/stretchr/testify/assert"
+	"testing"
 
 	"github.com/sirupsen/logrus"
-	"go.uber.org/zap"
-	"testing"
 )
-
-func TestZapLoggerWithConfig(t *testing.T) {
-	config := Configuration{
-		EnableConsole:     true,
-		ConsoleLevel:      Debug,
-		ConsoleJSONFormat: true,
-		EnableFile:        false,
-		FileLevel:         Info,
-		FileJSONFormat:    true,
-		Filename:          "log.log",
-	}
-
-	log := NewZapLoggerWithConfig(config)
-
-	contextLogger := log.WithFields(Fields{"key1": "value1"})
-	contextLogger.Debugf("Starting with zap")
-	contextLogger.Infof("Zap is awesome")
-}
-
-func TestZapLogger(t *testing.T) {
-	zapLogger, err := zap.NewProduction()
-	assert.Nil(t, err)
-
-	log := NewZapLogger(zapLogger.Sugar())
-
-	contextLogger := log.WithFields(Fields{"key1": "value1"})
-	contextLogger.Debugf("Starting with zap")
-	contextLogger.Infof("Zap is awesome")
-}
 
 func TestLogrusLoggerWithConfig(t *testing.T) {
 	config := Configuration{

--- a/logger/zap/zap_test.go
+++ b/logger/zap/zap_test.go
@@ -1,0 +1,39 @@
+package zap_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vmware-go-kcl/logger"
+	"github.com/vmware/vmware-go-kcl/logger/zap"
+	uzap "go.uber.org/zap"
+)
+
+func TestZapLoggerWithConfig(t *testing.T) {
+	config := logger.Configuration{
+		EnableConsole:     true,
+		ConsoleLevel:      logger.Debug,
+		ConsoleJSONFormat: true,
+		EnableFile:        false,
+		FileLevel:         logger.Info,
+		FileJSONFormat:    true,
+		Filename:          "log.log",
+	}
+
+	log := zap.NewZapLoggerWithConfig(config)
+
+	contextLogger := log.WithFields(logger.Fields{"key1": "value1"})
+	contextLogger.Debugf("Starting with zap")
+	contextLogger.Infof("Zap is awesome")
+}
+
+func TestZapLogger(t *testing.T) {
+	zapLogger, err := uzap.NewProduction()
+	assert.Nil(t, err)
+
+	log := zap.NewZapLogger(zapLogger.Sugar())
+
+	contextLogger := log.WithFields(logger.Fields{"key1": "value1"})
+	contextLogger.Debugf("Starting with zap")
+	contextLogger.Infof("Zap is awesome")
+}


### PR DESCRIPTION
Since #27 vmware-go-kcl has support the any logger interface,
which is very nice.

However due to the fact that `logger/zap.go` directly imports zap.
zap became a dependency of whoever uses `vmware-go-kcl.` The
problem is that zap also has many dependencies.

In order to avoid KCL users to pay a cost for a feature they don't
need, the zap stuff has been moved to a `logger/zap` sub-package.

Fixes #45