### PR TITLE
Fix the broken integrationt test

### DIFF
--- a/test/logger_test.go
+++ b/test/logger_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/vmware/vmware-go-kcl/logger"
+	zaplogger "github.com/vmware/vmware-go-kcl/logger/zap"
 )
 
 func TestZapLoggerWithConfig(t *testing.T) {
@@ -41,7 +42,7 @@ func TestZapLoggerWithConfig(t *testing.T) {
 		Filename:          "log.log",
 	}
 
-	log := logger.NewZapLoggerWithConfig(config)
+	log := zaplogger.NewZapLoggerWithConfig(config)
 
 	contextLogger := log.WithFields(logger.Fields{"key1": "value1"})
 	contextLogger.Debugf("Starting with zap")
@@ -52,7 +53,7 @@ func TestZapLogger(t *testing.T) {
 	zapLogger, err := zap.NewProduction()
 	assert.Nil(t, err)
 
-	log := logger.NewZapLogger(zapLogger.Sugar())
+	log := zaplogger.NewZapLogger(zapLogger.Sugar())
 
 	contextLogger := log.WithFields(logger.Fields{"key1": "value1"})
 	contextLogger.Debugf("Starting with zap")

--- a/test/worker_test.go
+++ b/test/worker_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/vmware/vmware-go-kcl/clientlibrary/utils"
 	wk "github.com/vmware/vmware-go-kcl/clientlibrary/worker"
 	"github.com/vmware/vmware-go-kcl/logger"
+	zaplogger "github.com/vmware/vmware-go-kcl/logger/zap"
 )
 
 const (
@@ -109,7 +110,7 @@ func TestWorkerWithSigInt(t *testing.T) {
 	// At miminal. use standard zap logger
 	//zapLogger, err := zap.NewProduction()
 	//assert.Nil(t, err)
-	//log := logger.NewZapLogger(zapLogger.Sugar())
+	//log := zaplogger.NewZapLogger(zapLogger.Sugar())
 	//
 	// In order to have precise control over logging. Use logger with config.
 	config := logger.Configuration{
@@ -122,7 +123,7 @@ func TestWorkerWithSigInt(t *testing.T) {
 		Filename:          "log.log",
 	}
 	// use zap logger
-	log := logger.NewZapLoggerWithConfig(config)
+	log := zaplogger.NewZapLoggerWithConfig(config)
 
 	kclConfig := cfg.NewKinesisClientLibConfig("appName", streamName, regionName, workerID).
 		WithInitialPositionInStream(cfg.LATEST).


### PR DESCRIPTION
The https://github.com/vmware/vmware-go-kcl/pull/47 move zap
into its own packge but it also breaks the integration test.
This change is to fix integ test by correcting its package
reference.

Signed-off-by: Tao Jiang <taoj@vmware.com>