### PR TITLE
Expose monitoring service

### DIFF
--- a/clientlibrary/checkpoint/dynamodb-checkpointer_test.go
+++ b/clientlibrary/checkpoint/dynamodb-checkpointer_test.go
@@ -67,9 +67,8 @@ func TestGetLeaseNotAquired(t *testing.T) {
 		WithMaxRecords(10).
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
-		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20)
+		WithFailoverTimeMillis(300000)
+
 	checkpoint := NewDynamoCheckpoint(kclConfig).WithDynamoDB(svc)
 	checkpoint.Init()
 	err := checkpoint.GetLease(&par.ShardStatus{
@@ -98,9 +97,8 @@ func TestGetLeaseAquired(t *testing.T) {
 		WithMaxRecords(10).
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
-		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20)
+		WithFailoverTimeMillis(300000)
+
 	checkpoint := NewDynamoCheckpoint(kclConfig).WithDynamoDB(svc)
 	checkpoint.Init()
 	marshalledCheckpoint := map[string]*dynamodb.AttributeValue{

--- a/clientlibrary/common/errors.go
+++ b/clientlibrary/common/errors.go
@@ -67,7 +67,7 @@ var errorMap = map[ErrorCode]ClientLibraryError{
 	KinesisClientLibRetryableError:  {ErrorCode: KinesisClientLibRetryableError, Retryable: true, Status: http.StatusServiceUnavailable, Msg: "Retryable exceptions (e.g. transient errors). The request/operation is expected to succeed upon (back off and) retry."},
 	KinesisClientLibIOError:         {ErrorCode: KinesisClientLibIOError, Retryable: true, Status: http.StatusServiceUnavailable, Msg: "Error in reading/writing information (e.g. shard information from Kinesis may not be current/complete)."},
 	BlockedOnParentShardError:       {ErrorCode: BlockedOnParentShardError, Retryable: true, Status: http.StatusServiceUnavailable, Msg: "Cannot start processing data for a shard because the data from the parent shard has not been completely processed (yet)."},
-	KinesisClientLibDependencyError: {ErrorCode: KinesisClientLibDependencyError, Retryable: true, Status: http.StatusServiceUnavailable, Msg: "Cannot talk to its dependencies (e.g. fetching data from Kinesis, DynamoDB table reads/writes, emitting metrics to CloudWatch)."},
+	KinesisClientLibDependencyError: {ErrorCode: KinesisClientLibDependencyError, Retryable: true, Status: http.StatusServiceUnavailable, Msg: "Cannot talk to its dependencies (e.g. fetching data from Kinesis, DynamoDB table reads/writes)."},
 	ThrottlingError:                 {ErrorCode: ThrottlingError, Retryable: true, Status: http.StatusTooManyRequests, Msg: "Requests are throttled by a service (e.g. DynamoDB when storing a checkpoint)."},
 
 	// Non-Retryable

--- a/clientlibrary/config/config.go
+++ b/clientlibrary/config/config.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	creds "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/vmware/vmware-go-kcl/clientlibrary/metrics"
 	"github.com/vmware/vmware-go-kcl/logger"
 )
 
@@ -245,6 +246,9 @@ type (
 
 		// Logger used to log message.
 		Logger logger.Logger
+
+		// MonitoringService publishes per worker-scoped metrics.
+		MonitoringService metrics.MonitoringService
 	}
 )
 

--- a/clientlibrary/config/config.go
+++ b/clientlibrary/config/config.go
@@ -184,7 +184,7 @@ type (
 		// InitialPositionInStreamExtended provides actual AT_TMESTAMP value
 		InitialPositionInStreamExtended InitialPositionInStreamExtended
 
-		// credentials to access Kinesis/Dynamo/CloudWatch: https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/
+		// credentials to access Kinesis/Dynamo: https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/
 		// Note: No need to configure here. Use NewEnvCredentials for testing and EC2RoleProvider for production
 
 		// FailoverTimeMillis Lease duration (leases not renewed within this period will be claimed by others)
@@ -211,7 +211,6 @@ type (
 
 		// kinesisClientConfig Client Configuration used by Kinesis client
 		// dynamoDBClientConfig Client Configuration used by DynamoDB client
-		// cloudWatchClientConfig Client Configuration used by CloudWatch client
 		// Note: we will use default client provided by AWS SDK
 
 		// TaskBackoffTimeMillis Backoff period when tasks encounter an exception

--- a/clientlibrary/config/config.go
+++ b/clientlibrary/config/config.go
@@ -88,12 +88,6 @@ const (
 	// Backoff time in milliseconds for Amazon Kinesis Client Library tasks (in the event of failures).
 	DEFAULT_TASK_BACKOFF_TIME_MILLIS = 500
 
-	// Buffer metrics for at most this long before publishing to CloudWatch.
-	DEFAULT_METRICS_BUFFER_TIME_MILLIS = 10000
-
-	// Buffer at most this many metrics before publishing to CloudWatch.
-	DEFAULT_METRICS_MAX_QUEUE_SIZE = 10000
-
 	// KCL will validate client provided sequence numbers with a call to Amazon Kinesis before
 	// checkpointing for calls to {@link RecordProcessorCheckpointer#checkpoint(String)} by default.
 	DEFAULT_VALIDATE_SEQUENCE_NUMBER_BEFORE_CHECKPOINTING = true
@@ -174,9 +168,6 @@ type (
 		// DynamoDBCredentials is used to access DynamoDB
 		DynamoDBCredentials *creds.Credentials
 
-		// CloudWatchCredentials is used to access CloudWatch
-		CloudWatchCredentials *creds.Credentials
-
 		// TableName is name of the dynamo db table for managing kinesis stream default to ApplicationName
 		TableName string
 
@@ -224,12 +215,6 @@ type (
 
 		// TaskBackoffTimeMillis Backoff period when tasks encounter an exception
 		TaskBackoffTimeMillis int
-
-		// MetricsBufferTimeMillis Metrics are buffered for at most this long before publishing to CloudWatch
-		MetricsBufferTimeMillis int
-
-		// MetricsMaxQueueSize Max number of metrics to buffer before publishing to CloudWatch
-		MetricsMaxQueueSize int
 
 		// ValidateSequenceNumberBeforeCheckpointing whether KCL should validate client provided sequence numbers
 		ValidateSequenceNumberBeforeCheckpointing bool

--- a/clientlibrary/config/config_test.go
+++ b/clientlibrary/config/config_test.go
@@ -32,12 +32,10 @@ func TestConfig(t *testing.T) {
 		WithInitialPositionInStream(TRIM_HORIZON).
 		WithIdleTimeBetweenReadsInMillis(20).
 		WithCallProcessRecordsEvenForEmptyRecordList(true).
-		WithTaskBackoffTimeMillis(10).
-		WithMetricsBufferTimeMillis(500).
-		WithMetricsMaxQueueSize(200)
+		WithTaskBackoffTimeMillis(10)
 
 	assert.Equal(t, "appName", kclConfig.ApplicationName)
-	assert.Equal(t, 500, kclConfig.FailoverTimeMillis)
+	assert.Equal(t, 500, kclConfig.TaskBackoffTimeMillis)
 
 	contextLogger := kclConfig.Logger.WithFields(logger.Fields{"key1": "value1"})
 	contextLogger.Debugf("Starting with default logger")

--- a/clientlibrary/config/kcl-config.go
+++ b/clientlibrary/config/kcl-config.go
@@ -37,6 +37,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/vmware/vmware-go-kcl/clientlibrary/metrics"
+
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/utils"
 	"github.com/vmware/vmware-go-kcl/logger"
@@ -193,5 +195,13 @@ func (c *KinesisClientLibConfiguration) WithLogger(logger logger.Logger) *Kinesi
 		log.Panic("Logger cannot be null")
 	}
 	c.Logger = logger
+	return c
+}
+
+// WithMonitoringService sets the monitoring service to use to publish metrics.
+func (c *KinesisClientLibConfiguration) WithMonitoringService(mService metrics.MonitoringService) *KinesisClientLibConfiguration {
+	// Nil case is handled downward (at worker creation) so no need to do it here.
+	// Plus the user might want to be explicit about passing a nil monitoring service here.
+	c.MonitoringService = mService
 	return c
 }

--- a/clientlibrary/config/kcl-config.go
+++ b/clientlibrary/config/kcl-config.go
@@ -42,21 +42,21 @@ import (
 	"github.com/vmware/vmware-go-kcl/logger"
 )
 
-// NewKinesisClientLibConfig to create a default KinesisClientLibConfiguration based on the required fields.
+// NewKinesisClientLibConfig creates a default KinesisClientLibConfiguration based on the required fields.
 func NewKinesisClientLibConfig(applicationName, streamName, regionName, workerID string) *KinesisClientLibConfiguration {
 	return NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regionName, workerID,
-		nil, nil, nil)
+		nil, nil)
 }
 
-// NewKinesisClientLibConfig to create a default KinesisClientLibConfiguration based on the required fields.
+// NewKinesisClientLibConfigWithCredential creates a default KinesisClientLibConfiguration based on the required fields and unique credentials.
 func NewKinesisClientLibConfigWithCredential(applicationName, streamName, regionName, workerID string,
 	creds *credentials.Credentials) *KinesisClientLibConfiguration {
-	return NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regionName, workerID, creds, creds, creds)
+	return NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regionName, workerID, creds, creds)
 }
 
-// NewKinesisClientLibConfig to create a default KinesisClientLibConfiguration based on the required fields.
+// NewKinesisClientLibConfigWithCredentials creates a default KinesisClientLibConfiguration based on the required fields and specific credentials for each service.
 func NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regionName, workerID string,
-	kiniesisCreds, dynamodbCreds, cloudwatchCreds *credentials.Credentials) *KinesisClientLibConfiguration {
+	kiniesisCreds, dynamodbCreds *credentials.Credentials) *KinesisClientLibConfiguration {
 	checkIsValueNotEmpty("ApplicationName", applicationName)
 	checkIsValueNotEmpty("StreamName", streamName)
 	checkIsValueNotEmpty("RegionName", regionName)
@@ -70,7 +70,6 @@ func NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regio
 		ApplicationName:                                  applicationName,
 		KinesisCredentials:                               kiniesisCreds,
 		DynamoDBCredentials:                              dynamodbCreds,
-		CloudWatchCredentials:                            cloudwatchCreds,
 		TableName:                                        applicationName,
 		StreamName:                                       streamName,
 		RegionName:                                       regionName,
@@ -85,8 +84,6 @@ func NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regio
 		ShardSyncIntervalMillis:                          DEFAULT_SHARD_SYNC_INTERVAL_MILLIS,
 		CleanupTerminatedShardsBeforeExpiry:              DEFAULT_CLEANUP_LEASES_UPON_SHARDS_COMPLETION,
 		TaskBackoffTimeMillis:                            DEFAULT_TASK_BACKOFF_TIME_MILLIS,
-		MetricsBufferTimeMillis:                          DEFAULT_METRICS_BUFFER_TIME_MILLIS,
-		MetricsMaxQueueSize:                              DEFAULT_METRICS_MAX_QUEUE_SIZE,
 		ValidateSequenceNumberBeforeCheckpointing:        DEFAULT_VALIDATE_SEQUENCE_NUMBER_BEFORE_CHECKPOINTING,
 		ShutdownGraceMillis:                              DEFAULT_SHUTDOWN_GRACE_MILLIS,
 		MaxLeasesForWorker:                               DEFAULT_MAX_LEASES_FOR_WORKER,
@@ -188,20 +185,6 @@ func (c *KinesisClientLibConfiguration) WithCallProcessRecordsEvenForEmptyRecord
 func (c *KinesisClientLibConfiguration) WithTaskBackoffTimeMillis(taskBackoffTimeMillis int) *KinesisClientLibConfiguration {
 	checkIsValuePositive("TaskBackoffTimeMillis", taskBackoffTimeMillis)
 	c.TaskBackoffTimeMillis = taskBackoffTimeMillis
-	return c
-}
-
-// WithMetricsBufferTimeMillis configures Metrics are buffered for at most this long before publishing to CloudWatch
-func (c *KinesisClientLibConfiguration) WithMetricsBufferTimeMillis(metricsBufferTimeMillis int) *KinesisClientLibConfiguration {
-	checkIsValuePositive("MetricsBufferTimeMillis", metricsBufferTimeMillis)
-	c.MetricsBufferTimeMillis = metricsBufferTimeMillis
-	return c
-}
-
-// WithMetricsMaxQueueSize configures Max number of metrics to buffer before publishing to CloudWatch
-func (c *KinesisClientLibConfiguration) WithMetricsMaxQueueSize(metricsMaxQueueSize int) *KinesisClientLibConfiguration {
-	checkIsValuePositive("MetricsMaxQueueSize", metricsMaxQueueSize)
-	c.MetricsMaxQueueSize = metricsMaxQueueSize
 	return c
 }
 

--- a/clientlibrary/metrics/cloudwatch/cloudwatch.go
+++ b/clientlibrary/metrics/cloudwatch/cloudwatch.go
@@ -25,7 +25,7 @@
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-package metrics
+package cloudwatch
 
 import (
 	"sync"
@@ -34,7 +34,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	cwatch "github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 
 	"github.com/vmware/vmware-go-kcl/logger"
@@ -43,7 +43,7 @@ import (
 // Buffer metrics for at most this long before publishing to CloudWatch.
 const DEFAULT_CLOUDWATCH_METRICS_BUFFER_DURATION = 10 * time.Second
 
-type CloudWatchMonitoringService struct {
+type MonitoringService struct {
 	appName     string
 	streamName  string
 	workerID    string
@@ -61,6 +61,8 @@ type CloudWatchMonitoringService struct {
 }
 
 type cloudWatchMetrics struct {
+	sync.Mutex
+
 	processedRecords   int64
 	processedBytes     int64
 	behindLatestMillis []float64
@@ -68,19 +70,17 @@ type cloudWatchMetrics struct {
 	leaseRenewals      int64
 	getRecordsTime     []float64
 	processRecordsTime []float64
-	sync.Mutex
 }
 
-// NewDefaultCloudWatchMonitoringService returns a CloudWatchMonitoringService
-// with the provided credentials.
-func NewDefaultCloudWatchMonitoringService(region string, creds *credentials.Credentials) *CloudWatchMonitoringService {
-	return NewDetailedCloudWatchMonitoringService(region, creds, logger.GetDefaultLogger(), DEFAULT_CLOUDWATCH_METRICS_BUFFER_DURATION)
+// NewMonitoringService returns a Monitoring service publishing metrics to CloudWatch.
+func NewMonitoringService(region string, creds *credentials.Credentials) *MonitoringService {
+	return NewMonitoringServiceWithOptions(region, creds, logger.GetDefaultLogger(), DEFAULT_CLOUDWATCH_METRICS_BUFFER_DURATION)
 }
 
-// NewDetailedCloudWatchMonitoringService returns a CloudWatchMonitoringService
-// with the provided credentials, buffering duration and logger.
-func NewDetailedCloudWatchMonitoringService(region string, creds *credentials.Credentials, logger logger.Logger, bufferDur time.Duration) *CloudWatchMonitoringService {
-	return &CloudWatchMonitoringService{
+// NewMonitoringServiceWithOptions returns a Monitoring service publishing metrics to
+// CloudWatch with the provided credentials, buffering duration and logger.
+func NewMonitoringServiceWithOptions(region string, creds *credentials.Credentials, logger logger.Logger, bufferDur time.Duration) *MonitoringService {
+	return &MonitoringService{
 		region:         region,
 		credentials:    creds,
 		logger:         logger,
@@ -88,7 +88,7 @@ func NewDetailedCloudWatchMonitoringService(region string, creds *credentials.Cr
 	}
 }
 
-func (cw *CloudWatchMonitoringService) Init(appName, streamName, workerID string) error {
+func (cw *MonitoringService) Init(appName, streamName, workerID string) error {
 	cfg := &aws.Config{Region: aws.String(cw.region)}
 	cfg.Credentials = cw.credentials
 	s, err := session.NewSession(cfg)
@@ -96,7 +96,7 @@ func (cw *CloudWatchMonitoringService) Init(appName, streamName, workerID string
 		cw.logger.Errorf("Error in creating session for cloudwatch. %+v", err)
 		return err
 	}
-	cw.svc = cloudwatch.New(s)
+	cw.svc = cwatch.New(s)
 	cw.shardMetrics = new(sync.Map)
 
 	stopChan := make(chan struct{})
@@ -107,14 +107,14 @@ func (cw *CloudWatchMonitoringService) Init(appName, streamName, workerID string
 	return nil
 }
 
-func (cw *CloudWatchMonitoringService) Start() error {
+func (cw *MonitoringService) Start() error {
 	cw.waitGroup.Add(1)
 	// entering eventloop for sending metrics to CloudWatch
 	go cw.eventloop()
 	return nil
 }
 
-func (cw *CloudWatchMonitoringService) Shutdown() {
+func (cw *MonitoringService) Shutdown() {
 	cw.logger.Infof("Shutting down cloudwatch metrics system...")
 	close(*cw.stop)
 	cw.waitGroup.Wait()
@@ -122,7 +122,7 @@ func (cw *CloudWatchMonitoringService) Shutdown() {
 }
 
 // Start daemon to flush metrics periodically
-func (cw *CloudWatchMonitoringService) eventloop() {
+func (cw *MonitoringService) eventloop() {
 	defer cw.waitGroup.Done()
 
 	for {
@@ -142,9 +142,9 @@ func (cw *CloudWatchMonitoringService) eventloop() {
 	}
 }
 
-func (cw *CloudWatchMonitoringService) flushShard(shard string, metric *cloudWatchMetrics) bool {
+func (cw *MonitoringService) flushShard(shard string, metric *cloudWatchMetrics) bool {
 	metric.Lock()
-	defaultDimensions := []*cloudwatch.Dimension{
+	defaultDimensions := []*cwatch.Dimension{
 		{
 			Name:  aws.String("Shard"),
 			Value: &shard,
@@ -155,7 +155,7 @@ func (cw *CloudWatchMonitoringService) flushShard(shard string, metric *cloudWat
 		},
 	}
 
-	leaseDimensions := []*cloudwatch.Dimension{
+	leaseDimensions := []*cwatch.Dimension{
 		{
 			Name:  aws.String("Shard"),
 			Value: &shard,
@@ -171,7 +171,7 @@ func (cw *CloudWatchMonitoringService) flushShard(shard string, metric *cloudWat
 	}
 	metricTimestamp := time.Now()
 
-	data := []*cloudwatch.MetricDatum{
+	data := []*cwatch.MetricDatum{
 		{
 			Dimensions: defaultDimensions,
 			MetricName: aws.String("RecordsProcessed"),
@@ -203,12 +203,12 @@ func (cw *CloudWatchMonitoringService) flushShard(shard string, metric *cloudWat
 	}
 
 	if len(metric.behindLatestMillis) > 0 {
-		data = append(data, &cloudwatch.MetricDatum{
+		data = append(data, &cwatch.MetricDatum{
 			Dimensions: defaultDimensions,
 			MetricName: aws.String("MillisBehindLatest"),
 			Unit:       aws.String("Milliseconds"),
 			Timestamp:  &metricTimestamp,
-			StatisticValues: &cloudwatch.StatisticSet{
+			StatisticValues: &cwatch.StatisticSet{
 				SampleCount: aws.Float64(float64(len(metric.behindLatestMillis))),
 				Sum:         sumFloat64(metric.behindLatestMillis),
 				Maximum:     maxFloat64(metric.behindLatestMillis),
@@ -217,12 +217,12 @@ func (cw *CloudWatchMonitoringService) flushShard(shard string, metric *cloudWat
 	}
 
 	if len(metric.getRecordsTime) > 0 {
-		data = append(data, &cloudwatch.MetricDatum{
+		data = append(data, &cwatch.MetricDatum{
 			Dimensions: defaultDimensions,
 			MetricName: aws.String("KinesisDataFetcher.getRecords.Time"),
 			Unit:       aws.String("Milliseconds"),
 			Timestamp:  &metricTimestamp,
-			StatisticValues: &cloudwatch.StatisticSet{
+			StatisticValues: &cwatch.StatisticSet{
 				SampleCount: aws.Float64(float64(len(metric.getRecordsTime))),
 				Sum:         sumFloat64(metric.getRecordsTime),
 				Maximum:     maxFloat64(metric.getRecordsTime),
@@ -231,12 +231,12 @@ func (cw *CloudWatchMonitoringService) flushShard(shard string, metric *cloudWat
 	}
 
 	if len(metric.processRecordsTime) > 0 {
-		data = append(data, &cloudwatch.MetricDatum{
+		data = append(data, &cwatch.MetricDatum{
 			Dimensions: defaultDimensions,
 			MetricName: aws.String("RecordProcessor.processRecords.Time"),
 			Unit:       aws.String("Milliseconds"),
 			Timestamp:  &metricTimestamp,
-			StatisticValues: &cloudwatch.StatisticSet{
+			StatisticValues: &cwatch.StatisticSet{
 				SampleCount: aws.Float64(float64(len(metric.processRecordsTime))),
 				Sum:         sumFloat64(metric.processRecordsTime),
 				Maximum:     maxFloat64(metric.processRecordsTime),
@@ -245,7 +245,7 @@ func (cw *CloudWatchMonitoringService) flushShard(shard string, metric *cloudWat
 	}
 
 	// Publish metrics data to cloud watch
-	_, err := cw.svc.PutMetricData(&cloudwatch.PutMetricDataInput{
+	_, err := cw.svc.PutMetricData(&cwatch.PutMetricDataInput{
 		Namespace:  aws.String(cw.appName),
 		MetricData: data,
 	})
@@ -265,7 +265,7 @@ func (cw *CloudWatchMonitoringService) flushShard(shard string, metric *cloudWat
 	return true
 }
 
-func (cw *CloudWatchMonitoringService) flush() error {
+func (cw *MonitoringService) flush() error {
 	cw.logger.Debugf("Flushing metrics data. Stream: %s, Worker: %s", cw.streamName, cw.workerID)
 	// publish per shard metrics
 	cw.shardMetrics.Range(func(k, v interface{}) bool {
@@ -276,62 +276,62 @@ func (cw *CloudWatchMonitoringService) flush() error {
 	return nil
 }
 
-func (cw *CloudWatchMonitoringService) IncrRecordsProcessed(shard string, count int) {
+func (cw *MonitoringService) IncrRecordsProcessed(shard string, count int) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
 	m.processedRecords += int64(count)
 }
 
-func (cw *CloudWatchMonitoringService) IncrBytesProcessed(shard string, count int64) {
+func (cw *MonitoringService) IncrBytesProcessed(shard string, count int64) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
 	m.processedBytes += count
 }
 
-func (cw *CloudWatchMonitoringService) MillisBehindLatest(shard string, millSeconds float64) {
+func (cw *MonitoringService) MillisBehindLatest(shard string, millSeconds float64) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
 	m.behindLatestMillis = append(m.behindLatestMillis, millSeconds)
 }
 
-func (cw *CloudWatchMonitoringService) LeaseGained(shard string) {
+func (cw *MonitoringService) LeaseGained(shard string) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
 	m.leasesHeld++
 }
 
-func (cw *CloudWatchMonitoringService) LeaseLost(shard string) {
+func (cw *MonitoringService) LeaseLost(shard string) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
 	m.leasesHeld--
 }
 
-func (cw *CloudWatchMonitoringService) LeaseRenewed(shard string) {
+func (cw *MonitoringService) LeaseRenewed(shard string) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
 	m.leaseRenewals++
 }
 
-func (cw *CloudWatchMonitoringService) RecordGetRecordsTime(shard string, time float64) {
+func (cw *MonitoringService) RecordGetRecordsTime(shard string, time float64) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
 	m.getRecordsTime = append(m.getRecordsTime, time)
 }
-func (cw *CloudWatchMonitoringService) RecordProcessRecordsTime(shard string, time float64) {
+func (cw *MonitoringService) RecordProcessRecordsTime(shard string, time float64) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
 	m.processRecordsTime = append(m.processRecordsTime, time)
 }
 
-func (cw *CloudWatchMonitoringService) getOrCreatePerShardMetrics(shard string) *cloudWatchMetrics {
+func (cw *MonitoringService) getOrCreatePerShardMetrics(shard string) *cloudWatchMetrics {
 	var i interface{}
 	var ok bool
 	if i, ok = cw.shardMetrics.Load(shard); !ok {

--- a/clientlibrary/metrics/interfaces.go
+++ b/clientlibrary/metrics/interfaces.go
@@ -27,23 +27,8 @@
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package metrics
 
-import (
-	"fmt"
-	"github.com/vmware/vmware-go-kcl/logger"
-)
-
-// MonitoringConfiguration allows you to configure how record processing metrics are exposed
-type MonitoringConfiguration struct {
-	MonitoringService string // Type of monitoring to expose. Supported types are "prometheus"
-	Region            string
-	Prometheus        PrometheusMonitoringService
-	CloudWatch        CloudWatchMonitoringService
-	service           MonitoringService
-	Logger            logger.Logger
-}
-
 type MonitoringService interface {
-	Init() error
+	Init(appName, streamName, workerID string) error
 	Start() error
 	IncrRecordsProcessed(string, int)
 	IncrBytesProcessed(string, int64)
@@ -56,53 +41,18 @@ type MonitoringService interface {
 	Shutdown()
 }
 
-func (m *MonitoringConfiguration) Init(nameSpace, streamName string, workerID string) error {
-	if m.MonitoringService == "" {
-		m.service = &noopMonitoringService{}
-		return nil
-	}
+// NoopMonitoringService implements MonitoringService by does nothing.
+type NoopMonitoringService struct{}
 
-	// Config with default logger if logger is not specified.
-	if m.Logger == nil {
-		m.Logger = logger.GetDefaultLogger()
-	}
+func (NoopMonitoringService) Init(appName, streamName, workerID string) error { return nil }
+func (NoopMonitoringService) Start() error                                    { return nil }
+func (NoopMonitoringService) Shutdown()                                       {}
 
-	switch m.MonitoringService {
-	case "prometheus":
-		m.Prometheus.Namespace = nameSpace
-		m.Prometheus.KinesisStream = streamName
-		m.Prometheus.WorkerID = workerID
-		m.Prometheus.Region = m.Region
-		m.Prometheus.Logger = m.Logger
-		m.service = &m.Prometheus
-	case "cloudwatch":
-		m.CloudWatch.Namespace = nameSpace
-		m.CloudWatch.KinesisStream = streamName
-		m.CloudWatch.WorkerID = workerID
-		m.CloudWatch.Region = m.Region
-		m.CloudWatch.Logger = m.Logger
-		m.service = &m.CloudWatch
-	default:
-		return fmt.Errorf("Invalid monitoring service type %s", m.MonitoringService)
-	}
-	return m.service.Init()
-}
-
-func (m *MonitoringConfiguration) GetMonitoringService() MonitoringService {
-	return m.service
-}
-
-type noopMonitoringService struct{}
-
-func (n *noopMonitoringService) Init() error  { return nil }
-func (n *noopMonitoringService) Start() error { return nil }
-func (n *noopMonitoringService) Shutdown()    {}
-
-func (n *noopMonitoringService) IncrRecordsProcessed(shard string, count int)         {}
-func (n *noopMonitoringService) IncrBytesProcessed(shard string, count int64)         {}
-func (n *noopMonitoringService) MillisBehindLatest(shard string, millSeconds float64) {}
-func (n *noopMonitoringService) LeaseGained(shard string)                             {}
-func (n *noopMonitoringService) LeaseLost(shard string)                               {}
-func (n *noopMonitoringService) LeaseRenewed(shard string)                            {}
-func (n *noopMonitoringService) RecordGetRecordsTime(shard string, time float64)      {}
-func (n *noopMonitoringService) RecordProcessRecordsTime(shard string, time float64)  {}
+func (NoopMonitoringService) IncrRecordsProcessed(shard string, count int)         {}
+func (NoopMonitoringService) IncrBytesProcessed(shard string, count int64)         {}
+func (NoopMonitoringService) MillisBehindLatest(shard string, millSeconds float64) {}
+func (NoopMonitoringService) LeaseGained(shard string)                             {}
+func (NoopMonitoringService) LeaseLost(shard string)                               {}
+func (NoopMonitoringService) LeaseRenewed(shard string)                            {}
+func (NoopMonitoringService) RecordGetRecordsTime(shard string, time float64)      {}
+func (NoopMonitoringService) RecordProcessRecordsTime(shard string, time float64)  {}

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -58,22 +58,20 @@ type Worker struct {
 	kclConfig        *config.KinesisClientLibConfiguration
 	kc               kinesisiface.KinesisAPI
 	checkpointer     chk.Checkpointer
+	mService         metrics.MonitoringService
 
 	stop      *chan struct{}
 	waitGroup *sync.WaitGroup
 	done      bool
 
 	shardStatus map[string]*par.ShardStatus
-
-	mService metrics.MonitoringService
 }
 
 // NewWorker constructs a Worker instance for processing Kinesis stream data.
-func NewWorker(factory kcl.IRecordProcessorFactory, kclConfig *config.KinesisClientLibConfiguration, mService metrics.MonitoringService) *Worker {
-	if mService == nil {
-		// nil means noop monitor service. i.e. not emitting any metrics.
-		// we accept that, though the correct way to do it would be for the user
-		// to call WithoutMonitoringService on the kcl configuration.
+func NewWorker(factory kcl.IRecordProcessorFactory, kclConfig *config.KinesisClientLibConfiguration) *Worker {
+	var mService metrics.MonitoringService
+	if kclConfig.MonitoringService == nil {
+		// Replaces nil with noop monitor service (not emitting any metrics).
 		mService = metrics.NoopMonitoringService{}
 	}
 

--- a/test/worker_custom_test.go
+++ b/test/worker_custom_test.go
@@ -52,13 +52,13 @@ func TestWorkerInjectCheckpointer(t *testing.T) {
 	assert.Equal(t, streamName, kclConfig.StreamName)
 
 	// configure cloudwatch as metrics system
-	mService := getMetricsConfig(kclConfig, metricsSystem)
+	kclConfig.WithMonitoringService(getMetricsConfig(kclConfig, metricsSystem))
 
 	// custom checkpointer or a mock checkpointer.
 	checkpointer := chk.NewDynamoCheckpoint(kclConfig)
 
 	// Inject a custom checkpointer into the worker.
-	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, mService).
+	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig).
 		WithCheckpointer(checkpointer)
 
 	err := worker.Start()
@@ -107,7 +107,7 @@ func TestWorkerInjectKinesis(t *testing.T) {
 	assert.Equal(t, streamName, kclConfig.StreamName)
 
 	// configure cloudwatch as metrics system
-	mService := getMetricsConfig(kclConfig, metricsSystem)
+	kclConfig.WithMonitoringService(getMetricsConfig(kclConfig, metricsSystem))
 
 	// create custom Kinesis
 	s, err := session.NewSession(&aws.Config{
@@ -117,7 +117,7 @@ func TestWorkerInjectKinesis(t *testing.T) {
 	kc := kinesis.New(s)
 
 	// Inject a custom checkpointer into the worker.
-	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, mService).
+	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig).
 		WithKinesis(kc)
 
 	err = worker.Start()
@@ -152,7 +152,7 @@ func TestWorkerInjectKinesisAndCheckpointer(t *testing.T) {
 	assert.Equal(t, streamName, kclConfig.StreamName)
 
 	// configure cloudwatch as metrics system
-	mService := getMetricsConfig(kclConfig, metricsSystem)
+	kclConfig.WithMonitoringService(getMetricsConfig(kclConfig, metricsSystem))
 
 	// create custom Kinesis
 	s, err := session.NewSession(&aws.Config{
@@ -165,7 +165,7 @@ func TestWorkerInjectKinesisAndCheckpointer(t *testing.T) {
 	checkpointer := chk.NewDynamoCheckpoint(kclConfig)
 
 	// Inject both custom checkpointer and kinesis into the worker.
-	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, mService).
+	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig).
 		WithKinesis(kc).
 		WithCheckpointer(checkpointer)
 

--- a/test/worker_custom_test.go
+++ b/test/worker_custom_test.go
@@ -44,10 +44,7 @@ func TestWorkerInjectCheckpointer(t *testing.T) {
 		WithMaxRecords(10).
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
-		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20)
-
+		WithFailoverTimeMillis(300000)
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
 
@@ -55,13 +52,13 @@ func TestWorkerInjectCheckpointer(t *testing.T) {
 	assert.Equal(t, streamName, kclConfig.StreamName)
 
 	// configure cloudwatch as metrics system
-	metricsConfig := getMetricsConfig(kclConfig, metricsSystem)
+	mService := getMetricsConfig(kclConfig, metricsSystem)
 
 	// custom checkpointer or a mock checkpointer.
 	checkpointer := chk.NewDynamoCheckpoint(kclConfig)
 
 	// Inject a custom checkpointer into the worker.
-	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, metricsConfig).
+	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, mService).
 		WithCheckpointer(checkpointer)
 
 	err := worker.Start()
@@ -101,9 +98,7 @@ func TestWorkerInjectKinesis(t *testing.T) {
 		WithMaxRecords(10).
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
-		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20)
+		WithFailoverTimeMillis(300000)
 
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
@@ -112,7 +107,7 @@ func TestWorkerInjectKinesis(t *testing.T) {
 	assert.Equal(t, streamName, kclConfig.StreamName)
 
 	// configure cloudwatch as metrics system
-	metricsConfig := getMetricsConfig(kclConfig, metricsSystem)
+	mService := getMetricsConfig(kclConfig, metricsSystem)
 
 	// create custom Kinesis
 	s, err := session.NewSession(&aws.Config{
@@ -122,7 +117,7 @@ func TestWorkerInjectKinesis(t *testing.T) {
 	kc := kinesis.New(s)
 
 	// Inject a custom checkpointer into the worker.
-	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, metricsConfig).
+	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, mService).
 		WithKinesis(kc)
 
 	err = worker.Start()
@@ -148,9 +143,7 @@ func TestWorkerInjectKinesisAndCheckpointer(t *testing.T) {
 		WithMaxRecords(10).
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
-		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20)
+		WithFailoverTimeMillis(300000)
 
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
@@ -159,7 +152,7 @@ func TestWorkerInjectKinesisAndCheckpointer(t *testing.T) {
 	assert.Equal(t, streamName, kclConfig.StreamName)
 
 	// configure cloudwatch as metrics system
-	metricsConfig := getMetricsConfig(kclConfig, metricsSystem)
+	mService := getMetricsConfig(kclConfig, metricsSystem)
 
 	// create custom Kinesis
 	s, err := session.NewSession(&aws.Config{
@@ -172,7 +165,7 @@ func TestWorkerInjectKinesisAndCheckpointer(t *testing.T) {
 	checkpointer := chk.NewDynamoCheckpoint(kclConfig)
 
 	// Inject both custom checkpointer and kinesis into the worker.
-	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, metricsConfig).
+	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, mService).
 		WithKinesis(kc).
 		WithCheckpointer(checkpointer)
 

--- a/test/worker_test.go
+++ b/test/worker_test.go
@@ -75,8 +75,6 @@ func TestWorker(t *testing.T) {
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
 		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20).
 		WithLogger(log)
 
 	runTest(kclConfig, false, t)
@@ -131,8 +129,6 @@ func TestWorkerWithSigInt(t *testing.T) {
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
 		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20).
 		WithLogger(log)
 
 	runTest(kclConfig, true, t)
@@ -148,9 +144,7 @@ func TestWorkerStatic(t *testing.T) {
 		WithMaxRecords(10).
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
-		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20)
+		WithFailoverTimeMillis(300000)
 
 	runTest(kclConfig, false, t)
 }
@@ -172,9 +166,7 @@ func TestWorkerAssumeRole(t *testing.T) {
 		WithMaxRecords(10).
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
-		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20)
+		WithFailoverTimeMillis(300000)
 
 	runTest(kclConfig, false, t)
 }
@@ -184,9 +176,9 @@ func runTest(kclConfig *cfg.KinesisClientLibConfiguration, triggersig bool, t *t
 	assert.Equal(t, streamName, kclConfig.StreamName)
 
 	// configure cloudwatch as metrics system
-	metricsConfig := getMetricsConfig(kclConfig, metricsSystem)
+	mService := getMetricsConfig(kclConfig, metricsSystem)
 
-	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, metricsConfig)
+	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, mService)
 
 	err := worker.Start()
 	assert.Nil(t, err)
@@ -223,7 +215,7 @@ func runTest(kclConfig *cfg.KinesisClientLibConfiguration, triggersig bool, t *t
 	// wait a few seconds before shutdown processing
 	time.Sleep(10 * time.Second)
 
-	if metricsConfig != nil && metricsConfig.MonitoringService == "prometheus" {
+	if metricsSystem == "prometheus" {
 		res, err := http.Get("http://localhost:8080/metrics")
 		if err != nil {
 			t.Fatalf("Error scraping Prometheus endpoint %s", err)
@@ -244,30 +236,17 @@ func runTest(kclConfig *cfg.KinesisClientLibConfiguration, triggersig bool, t *t
 }
 
 // configure different metrics system
-func getMetricsConfig(kclConfig *cfg.KinesisClientLibConfiguration, service string) *metrics.MonitoringConfiguration {
+func getMetricsConfig(kclConfig *cfg.KinesisClientLibConfiguration, service string) metrics.MonitoringService {
+
 	if service == "cloudwatch" {
-		return &metrics.MonitoringConfiguration{
-			MonitoringService: "cloudwatch",
-			Region:            regionName,
-			Logger:            kclConfig.Logger,
-			CloudWatch: metrics.CloudWatchMonitoringService{
-				Credentials: kclConfig.CloudWatchCredentials,
-				// Those value should come from kclConfig
-				MetricsBufferTimeMillis: kclConfig.MetricsBufferTimeMillis,
-				MetricsMaxQueueSize:     kclConfig.MetricsMaxQueueSize,
-			},
-		}
+		return metrics.NewDetailedCloudWatchMonitoringService(kclConfig.RegionName,
+			kclConfig.KinesisCredentials,
+			kclConfig.Logger,
+			metrics.DEFAULT_CLOUDWATCH_METRICS_BUFFER_DURATION)
 	}
 
 	if service == "prometheus" {
-		return &metrics.MonitoringConfiguration{
-			MonitoringService: "prometheus",
-			Region:            regionName,
-			Logger:            kclConfig.Logger,
-			Prometheus: metrics.PrometheusMonitoringService{
-				ListenAddress: ":8080",
-			},
-		}
+		return metrics.NewPrometheusMonitoringService(":8080", regionName, kclConfig.Logger)
 	}
 
 	return nil

--- a/test/worker_test.go
+++ b/test/worker_test.go
@@ -97,8 +97,6 @@ func TestWorkerWithTimestamp(t *testing.T) {
 		WithMaxLeasesForWorker(1).
 		WithShardSyncIntervalMillis(5000).
 		WithFailoverTimeMillis(300000).
-		WithMetricsBufferTimeMillis(10000).
-		WithMetricsMaxQueueSize(20).
 		WithLogger(log)
 
 	runTest(kclConfig, false, t)
@@ -176,9 +174,9 @@ func runTest(kclConfig *cfg.KinesisClientLibConfiguration, triggersig bool, t *t
 	assert.Equal(t, streamName, kclConfig.StreamName)
 
 	// configure cloudwatch as metrics system
-	mService := getMetricsConfig(kclConfig, metricsSystem)
+	kclConfig.WithMonitoringService(getMetricsConfig(kclConfig, metricsSystem))
 
-	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig, mService)
+	worker := wk.NewWorker(recordProcessorFactory(t), kclConfig)
 
 	err := worker.Start()
 	assert.Nil(t, err)


### PR DESCRIPTION
KCL users may wish to implement their own monitoring service to use, say, Datadog, instead of Cloudwatch.
The monitoring service is a per worker component in the case of Cloudwatch (because of the internal caching goroutine) but this 1-1 relation between `Worker` and `MonitoringService` may not always be required, nor desirable.

To decouple kcl without losing any current functionality, I propose this PR:

 - decouples and removes any CloudWatch specific stuff/types from the config package
 - propose default/detail constructors for CloudWatch so that the use can configure the monitoring service independently from the kcl configuration.
 - slightly changes the API, `worker.NewWorker` now accepts a `metrics.MonitoringService` interface instead of `MonitoringConfiguration`, so that users can pass their own implementation. (We use Datadog in production with this branch at the moment).
 - Fixes test

No KCL internal logic has been modified, though I reckon this may be seem as a relatively important change about the setup of kcl, but i practice the only real difference is that you:
 - either have to create yourself an implementation of `MonitoringService` and pass it to `NewWorker`
 - or use one of the constructors.

I could have and would have liked to go further: as I did in  #47 I believe it would be preferable to not force users of this package to depend on prometheus nor cloudwatch. To do so, the CloudWatch and Prometheus implementations of `MonitoringService` could be broke up into their own packages. But it would be the subject of subsequent PR, if and when this one gets merged. 

