### PR TITLE
Fix broken tests

### DIFF
--- a/clientlibrary/config/config_test.go
+++ b/clientlibrary/config/config_test.go
@@ -35,7 +35,8 @@ func TestConfig(t *testing.T) {
 		WithTaskBackoffTimeMillis(10)
 
 	assert.Equal(t, "appName", kclConfig.ApplicationName)
-	assert.Equal(t, 500, kclConfig.TaskBackoffTimeMillis)
+	assert.Equal(t, 500, kclConfig.FailoverTimeMillis)
+	assert.Equal(t, 10, kclConfig.TaskBackoffTimeMillis)
 
 	contextLogger := kclConfig.Logger.WithFields(logger.Fields{"key1": "value1"})
 	contextLogger.Debugf("Starting with default logger")

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -69,8 +69,8 @@ type Worker struct {
 
 // NewWorker constructs a Worker instance for processing Kinesis stream data.
 func NewWorker(factory kcl.IRecordProcessorFactory, kclConfig *config.KinesisClientLibConfiguration) *Worker {
-	var mService metrics.MonitoringService
-	if kclConfig.MonitoringService == nil {
+	mService := kclConfig.MonitoringService
+	if mService == nil {
 		// Replaces nil with noop monitor service (not emitting any metrics).
 		mService = metrics.NoopMonitoringService{}
 	}

--- a/test/worker_test.go
+++ b/test/worker_test.go
@@ -35,6 +35,8 @@ import (
 	cfg "github.com/vmware/vmware-go-kcl/clientlibrary/config"
 	kc "github.com/vmware/vmware-go-kcl/clientlibrary/interfaces"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/metrics"
+	"github.com/vmware/vmware-go-kcl/clientlibrary/metrics/cloudwatch"
+	"github.com/vmware/vmware-go-kcl/clientlibrary/metrics/prometheus"
 	"github.com/vmware/vmware-go-kcl/clientlibrary/utils"
 	wk "github.com/vmware/vmware-go-kcl/clientlibrary/worker"
 	"github.com/vmware/vmware-go-kcl/logger"
@@ -237,14 +239,14 @@ func runTest(kclConfig *cfg.KinesisClientLibConfiguration, triggersig bool, t *t
 func getMetricsConfig(kclConfig *cfg.KinesisClientLibConfiguration, service string) metrics.MonitoringService {
 
 	if service == "cloudwatch" {
-		return metrics.NewDetailedCloudWatchMonitoringService(kclConfig.RegionName,
+		return cloudwatch.NewMonitoringServiceWithOptions(kclConfig.RegionName,
 			kclConfig.KinesisCredentials,
 			kclConfig.Logger,
-			metrics.DEFAULT_CLOUDWATCH_METRICS_BUFFER_DURATION)
+			cloudwatch.DEFAULT_CLOUDWATCH_METRICS_BUFFER_DURATION)
 	}
 
 	if service == "prometheus" {
-		return metrics.NewPrometheusMonitoringService(":8080", regionName, kclConfig.Logger)
+		return prometheus.NewMonitoringService(":8080", regionName, kclConfig.Logger)
 	}
 
 	return nil


### PR DESCRIPTION
Fix some broken unit and integ tests introduced by last commit.

Tests:
1. hmake test
2. Run integration test on Goland IDE and make sure all pass.

Signed-off-by: Tao Jiang <taoj@vmware.com>