### PR TITLE
Fix error in puslishing cloud watch metrics

### DIFF
--- a/clientlibrary/metrics/cloudwatch/cloudwatch.go
+++ b/clientlibrary/metrics/cloudwatch/cloudwatch.go
@@ -89,6 +89,10 @@ func NewMonitoringServiceWithOptions(region string, creds *credentials.Credentia
 }
 
 func (cw *MonitoringService) Init(appName, streamName, workerID string) error {
+	cw.appName = appName
+	cw.streamName = streamName
+	cw.workerID = workerID
+
 	cfg := &aws.Config{Region: aws.String(cw.region)}
 	cfg.Credentials = cw.credentials
 	s, err := session.NewSession(cfg)


### PR DESCRIPTION
Reported at:
https://github.com/vmware/vmware-go-kcl/issues/54

The input params are not used to set monitor service in cloudwatch
Init function. The empty appName, streamName and workerID cause
PutMetricData failed with error string "Error in publishing
cloudwatch metrics. Error: InvalidParameter...".

Signed-off-by: Tao Jiang <taoj@vmware.com>