### PR TITLE
Make the lease refresh period configurable

### DIFF
--- a/clientlibrary/checkpoint/dynamodb-checkpointer.go
+++ b/clientlibrary/checkpoint/dynamodb-checkpointer.go
@@ -135,7 +135,7 @@ func (checkpointer *DynamoCheckpoint) GetLease(shard *par.ShardStatus, newAssign
 			return err
 		}
 
-		if !time.Now().UTC().After(currentLeaseTimeout) && assignedTo != newAssignTo {
+		if time.Now().UTC().Before(currentLeaseTimeout) && assignedTo != newAssignTo {
 			return errors.New(ErrLeaseNotAquired)
 		}
 

--- a/clientlibrary/config/config.go
+++ b/clientlibrary/config/config.go
@@ -63,6 +63,9 @@ const (
 	// the number of DynamoDB IOPS required for tracking leases.
 	DEFAULT_FAILOVER_TIME_MILLIS = 10000
 
+	// Period before the end of lease during which a lease is refreshed by the owner.
+	DEFAULT_LEASE_REFRESH_PERIOD_MILLIS = 5000
+
 	// Max records to fetch from Kinesis in a single GetRecords call.
 	DEFAULT_MAX_RECORDS = 10000
 
@@ -190,7 +193,10 @@ type (
 		// FailoverTimeMillis Lease duration (leases not renewed within this period will be claimed by others)
 		FailoverTimeMillis int
 
-		/// MaxRecords Max records to read per Kinesis getRecords() call
+		// LeaseRefreshPeriodMillis is the period before the end of lease during which a lease is refreshed by the owner.
+		LeaseRefreshPeriodMillis int
+
+		// MaxRecords Max records to read per Kinesis getRecords() call
 		MaxRecords int
 
 		// IdleTimeBetweenReadsInMillis Idle time between calls to fetch data from Kinesis

--- a/clientlibrary/config/kcl-config.go
+++ b/clientlibrary/config/kcl-config.go
@@ -79,6 +79,7 @@ func NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regio
 		InitialPositionInStream:                          DEFAULT_INITIAL_POSITION_IN_STREAM,
 		InitialPositionInStreamExtended:                  *newInitialPosition(DEFAULT_INITIAL_POSITION_IN_STREAM),
 		FailoverTimeMillis:                               DEFAULT_FAILOVER_TIME_MILLIS,
+		LeaseRefreshPeriodMillis:                         DEFAULT_LEASE_REFRESH_PERIOD_MILLIS,
 		MaxRecords:                                       DEFAULT_MAX_RECORDS,
 		IdleTimeBetweenReadsInMillis:                     DEFAULT_IDLETIME_BETWEEN_READS_MILLIS,
 		CallProcessRecordsEvenForEmptyRecordList:         DEFAULT_DONT_CALL_PROCESS_RECORDS_FOR_EMPTY_RECORD_LIST,
@@ -130,6 +131,12 @@ func (c *KinesisClientLibConfiguration) WithTimestampAtInitialPositionInStream(t
 func (c *KinesisClientLibConfiguration) WithFailoverTimeMillis(failoverTimeMillis int) *KinesisClientLibConfiguration {
 	checkIsValuePositive("FailoverTimeMillis", failoverTimeMillis)
 	c.FailoverTimeMillis = failoverTimeMillis
+	return c
+}
+
+func (c *KinesisClientLibConfiguration) WithLeaseRefreshPeriodMillis(leaseRefreshPeriodMillis int) *KinesisClientLibConfiguration {
+	checkIsValuePositive("LeaseRefreshPeriodMillis", leaseRefreshPeriodMillis)
+	c.LeaseRefreshPeriodMillis = leaseRefreshPeriodMillis
 	return c
 }
 

--- a/clientlibrary/worker/shard-consumer.go
+++ b/clientlibrary/worker/shard-consumer.go
@@ -266,7 +266,7 @@ func (sc *ShardConsumer) getRecords(shard *par.ShardStatus) error {
 			shutdownInput := &kcl.ShutdownInput{ShutdownReason: kcl.REQUESTED, Checkpointer: recordCheckpointer}
 			sc.recordProcessor.Shutdown(shutdownInput)
 			return nil
-		case <-time.After(1 * time.Nanosecond):
+		default:
 		}
 	}
 }

--- a/clientlibrary/worker/shard-consumer.go
+++ b/clientlibrary/worker/shard-consumer.go
@@ -169,7 +169,7 @@ func (sc *ShardConsumer) getRecords(shard *par.ShardStatus) error {
 	retriedErrors := 0
 
 	for {
-		if time.Now().UTC().After(shard.LeaseTimeout.Add(-5 * time.Second)) {
+		if time.Now().UTC().After(shard.LeaseTimeout.Add(-time.Duration(sc.kclConfig.LeaseRefreshPeriodMillis) * time.Millisecond)) {
 			log.Debugf("Refreshing lease on shard: %s for worker: %s", shard.ID, sc.consumerID)
 			err = sc.checkpointer.GetLease(shard, sc.consumerID)
 			if err != nil {


### PR DESCRIPTION
### description

This PR proposes to render configurable the `5s` value hard-coded here:
https://github.com/vmware/vmware-go-kcl/blob/eca3d01e05738f915b32567ea702996539a6b850/clientlibrary/worker/shard-consumer.go#L172

I called this parameter `LeaseRefreshPeriodMillis` and its default value is 5s.

### rationale behind this change

For our specific use case we control the read throughput by performing a `time.Sleep` in the `ProcessRecords` method of our `RecordProcessor` implementation. This has the benefit to sensibly decrease the CPU usage (by performing less IO syscalls) while keeping the same average read throughput we would obtain by decreasing `MaxRecords`.

However for this use case the 5s value hard-coded here is not sufficient.

If the time taken by `GetRecords+ProcessRecords` exceed 5s then there is a problem:
 - current shard owner believes it will still own the shard 5 seconds later but, 
 - in fact this is not true, if `GetRecords+ProcessRecords` exceeds 5s then the lease duration will be reached and the shard might be offered to, and taken by, another worker.

This leads to records duplication because both the old and new shard owners will read from the current checkpoint until the lease end. In our use case this led to 4% record duplication.

On this screenshot showing the shard count for a stream with 20 shards, and 2 workers. With this fix the number of shards per worker stays constant at 10, while before the problem led to a never ending variation in the number of shards per worker. 
![image](https://user-images.githubusercontent.com/476650/68759882-dd48ca80-0610-11ea-8bc6-fbb4b6d94be0.png)

I reckon this behavior is amplified in our use case because `ProcessRecords` always takes more time than 5s but it could anyway happen in other cases: as the time taken by `GetRecords+ProcessRecords` is never guaranteed to be below 5s (due to IO delay for example).


### another, more correct solution

There would be another way to solve this: we could guarantee that `GetRecords+ProcessRecords` never exceeds a certain -configurable- amount of time. By using a [`context.WithDeadline`](https://golang.org/pkg/context/#WithDeadline) and passing it around, using [`GetRecordsWithContext`](https://github.com/aws/aws-sdk-go/blob/v1.25.30/service/kinesis/api.go#L1339) instead of `GetRecords`, and having the Checkpointer take a context as well (to forward it to [`PutItemWithContext`](https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/#DynamoDB.PutItemWithContext) instead of `PutItem`.

But this would be a breaking change as it would change many of the exported interfaces.