### PR TITLE
Make Worker.Shutdown() synchronous

### DIFF
--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -115,8 +115,12 @@ func (w *Worker) Start() error {
 	}
 
 	log.Infof("Starting worker event loop.")
-	// entering event loop
-	go w.eventLoop()
+	w.waitGroup.Add(1)
+	go func() {
+		defer w.waitGroup.Done()
+		// entering event loop
+		w.eventLoop()
+	}()
 	return nil
 }
 


### PR DESCRIPTION
Previously, a WaitGroup was used to track executing ShardConsumers
and prevent Worker.Shutdown() from returning until all ShardConsumers
had completed.  Unfortunately, it was possible for Shutdown() to race
with the eventLoop(), leading to a situation where Worker.Shutdown()
returns while a ShardConsumer is still executing.

Now, we increment the WaitGroup to keep track the eventLoop() as well
as the ShardConsumers.  This prevents shutdown from returning until all
background go-routines have completed.

Signed-off-by: Daniel Ferstay <dferstay@splunk.com>