### PR TITLE
Make Worker.Shutdown() synchronous

### DIFF
--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -117,8 +117,12 @@ func (w *Worker) Start() error {
 	}
 
 	log.Infof("Starting worker event loop.")
-	// entering event loop
-	go w.eventLoop()
+	w.waitGroup.Add(1)
+	go func() {
+		defer w.waitGroup.Done()
+		// entering event loop
+		w.eventLoop()
+	}()
 	return nil
 }
 


### PR DESCRIPTION
From https://github.com/vmware/vmware-go-kcl/issues/57

Worker.Shutdown() is not synchronous with exist of
background go-routines. Thus, it is possible for the
IRecordProcessor.ProcessRecords() method to be called after
the KCL Worker has been shutdown.

Now, we increment the WaitGroup to keep track the
eventLoop() as well as the ShardConsumers. This prevents
shutdown from returning until all background go-routines
have completed.

Bring over the change from master to v-1.0 branch
https://github.com/vmware/vmware-go-kcl/pull/58

Signed-off-by: Tao Jiang <taoj@vmware.com>