### PR TITLE
Fix potentially delayed shutdown on shard sync

### DIFF
--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -315,9 +315,8 @@ func (w *Worker) eventLoop() {
 		case <-*w.stop:
 			log.Infof("Shutting down...")
 			return
-		default:
-			log.Debugf("Trying to sync shards in %d ms...", shardSyncSleep)
-			time.Sleep(time.Duration(shardSyncSleep) * time.Millisecond)
+		case <-time.After(time.Duration(shardSyncSleep) * time.Millisecond):
+			log.Debugf("Waited %d ms to sync shards...", shardSyncSleep)
 		}
 	}
 }


### PR DESCRIPTION
Pull-request #62 wrongly introduced an increased delay on shutdown.

Before #62 the `stop` channel could be triggered while waiting for `syncShard` milliseconds, so the function could return as soon as `stop` was received.

However #62 changed this behavior by sleeping in the default case: `stop` couldn't be handled right away anymore. Instead it was handled after a whole new loop, potentially delaying shutdown by minutes. (up to synchard * 1.5 ms).

This commit fixes that.