### PR TITLE
Reduce log noise from found shards in worker event loop

### DIFF
--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -238,6 +238,7 @@ func (w *Worker) newShardConsumer(shard *par.ShardStatus) *ShardConsumer {
 func (w *Worker) eventLoop() {
 	log := w.kclConfig.Logger
 
+	var foundShards int
 	for {
 		// Add [-50%, +50%] random jitter to ShardSyncIntervalMillis. When multiple workers
 		// starts at the same time, this decreases the probability of them calling
@@ -252,7 +253,10 @@ func (w *Worker) eventLoop() {
 			continue
 		}
 
-		log.Infof("Found %d shards", len(w.shardStatus))
+		if foundShards == 0 || foundShards != len(w.shardStatus) {
+			foundShards = len(w.shardStatus)
+			log.Infof("Found %d shards", foundShards)
+		}
 
 		// Count the number of leases hold by this worker excluding the processed shard
 		counter := 0


### PR DESCRIPTION
KCL info logs are very noisy.

This PR modifies the worker event loop to only log the number of found shards if the number changes.

Before:
```
time="2020-01-21T14:11:04-08:00" level=info msg="Worker initialization in progress..."
time="2020-01-21T14:11:04-08:00" level=info msg="Creating Kinesis session"
time="2020-01-21T14:11:04-08:00" level=info msg="Use custom checkpointer implementation."
time="2020-01-21T14:11:04-08:00" level=info msg="Initializing Checkpointer"
time="2020-01-21T14:11:04-08:00" level=info msg="Creating DynamoDB session"
time="2020-01-21T14:11:04-08:00" level=info msg="Initialization complete."
time="2020-01-21T14:11:04-08:00" level=info msg="Starting monitoring service."
time="2020-01-21T14:11:04-08:00" level=info msg="Starting worker event loop."
time="2020-01-21T14:11:04-08:00" level=info msg="Found new shard with id shardId-000000000000"
time="2020-01-21T14:11:04-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:11:04-08:00" level=info msg="Start Shard Consumer for shard: shardId-000000000000"
time="2020-01-21T14:11:19-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:11:24-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:11:33-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:11:45-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:11:57-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:12:06-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:12:20-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:12:26-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:12:40-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:12:45-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:12:56-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:12:56-08:00" level=info msg="Found ...
```

After:

```
time="2020-01-21T14:11:04-08:00" level=info msg="Worker initialization in progress..."
time="2020-01-21T14:11:04-08:00" level=info msg="Creating Kinesis session"
time="2020-01-21T14:11:04-08:00" level=info msg="Use custom checkpointer implementation."
time="2020-01-21T14:11:04-08:00" level=info msg="Initializing Checkpointer"
time="2020-01-21T14:11:04-08:00" level=info msg="Creating DynamoDB session"
time="2020-01-21T14:11:04-08:00" level=info msg="Initialization complete."
time="2020-01-21T14:11:04-08:00" level=info msg="Starting monitoring service."
time="2020-01-21T14:11:04-08:00" level=info msg="Starting worker event loop."
time="2020-01-21T14:11:04-08:00" level=info msg="Found new shard with id shardId-000000000000"
time="2020-01-21T14:11:04-08:00" level=info msg="Found 1 shards"
time="2020-01-21T14:11:04-08:00" level=info msg="Start Shard Consumer for shard: shardId-000000000000"
```