### PR TITLE
Prometheus convention is seconds

### DIFF
--- a/clientlibrary/metrics/cloudwatch/cloudwatch.go
+++ b/clientlibrary/metrics/cloudwatch/cloudwatch.go
@@ -294,11 +294,11 @@ func (cw *MonitoringService) IncrBytesProcessed(shard string, count int64) {
 	m.processedBytes += count
 }
 
-func (cw *MonitoringService) MillisBehindLatest(shard string, millSeconds float64) {
+func (cw *MonitoringService) MillisBehindLatest(shard string, millis float64) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
-	m.behindLatestMillis = append(m.behindLatestMillis, millSeconds)
+	m.behindLatestMillis = append(m.behindLatestMillis, millis)
 }
 
 func (cw *MonitoringService) LeaseGained(shard string) {
@@ -322,17 +322,17 @@ func (cw *MonitoringService) LeaseRenewed(shard string) {
 	m.leaseRenewals++
 }
 
-func (cw *MonitoringService) RecordGetRecordsTime(shard string, time float64) {
+func (cw *MonitoringService) RecordGetRecordsTime(shard string, millis float64) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
-	m.getRecordsTime = append(m.getRecordsTime, time)
+	m.getRecordsTime = append(m.getRecordsTime, millis)
 }
-func (cw *MonitoringService) RecordProcessRecordsTime(shard string, time float64) {
+func (cw *MonitoringService) RecordProcessRecordsTime(shard string, millis float64) {
 	m := cw.getOrCreatePerShardMetrics(shard)
 	m.Lock()
 	defer m.Unlock()
-	m.processRecordsTime = append(m.processRecordsTime, time)
+	m.processRecordsTime = append(m.processRecordsTime, millis)
 }
 
 func (cw *MonitoringService) getOrCreatePerShardMetrics(shard string) *cloudWatchMetrics {

--- a/clientlibrary/metrics/interfaces.go
+++ b/clientlibrary/metrics/interfaces.go
@@ -48,11 +48,11 @@ func (NoopMonitoringService) Init(appName, streamName, workerID string) error { 
 func (NoopMonitoringService) Start() error                                    { return nil }
 func (NoopMonitoringService) Shutdown()                                       {}
 
-func (NoopMonitoringService) IncrRecordsProcessed(shard string, count int)         {}
-func (NoopMonitoringService) IncrBytesProcessed(shard string, count int64)         {}
-func (NoopMonitoringService) MillisBehindLatest(shard string, millSeconds float64) {}
-func (NoopMonitoringService) LeaseGained(shard string)                             {}
-func (NoopMonitoringService) LeaseLost(shard string)                               {}
-func (NoopMonitoringService) LeaseRenewed(shard string)                            {}
-func (NoopMonitoringService) RecordGetRecordsTime(shard string, time float64)      {}
-func (NoopMonitoringService) RecordProcessRecordsTime(shard string, time float64)  {}
+func (NoopMonitoringService) IncrRecordsProcessed(shard string, count int)          {}
+func (NoopMonitoringService) IncrBytesProcessed(shard string, count int64)          {}
+func (NoopMonitoringService) MillisBehindLatest(shard string, millis float64)       {}
+func (NoopMonitoringService) LeaseGained(shard string)                              {}
+func (NoopMonitoringService) LeaseLost(shard string)                                {}
+func (NoopMonitoringService) LeaseRenewed(shard string)                             {}
+func (NoopMonitoringService) RecordGetRecordsTime(shard string, millis float64)     {}
+func (NoopMonitoringService) RecordProcessRecordsTime(shard string, millis float64) {}

--- a/clientlibrary/worker/shard-consumer.go
+++ b/clientlibrary/worker/shard-consumer.go
@@ -208,8 +208,7 @@ func (sc *ShardConsumer) getRecords(shard *par.ShardStatus) error {
 			return err
 		}
 
-		// Convert from nanoseconds to milliseconds
-		getRecordsTime := time.Since(getRecordsStartTime) / 1000000
+		getRecordsTime := time.Since(getRecordsStartTime).Milliseconds()
 		sc.mService.RecordGetRecordsTime(shard.ID, float64(getRecordsTime))
 
 		// reset the retry count after success
@@ -236,8 +235,7 @@ func (sc *ShardConsumer) getRecords(shard *par.ShardStatus) error {
 			// Delivery the events to the record processor
 			sc.recordProcessor.ProcessRecords(input)
 
-			// Convert from nanoseconds to milliseconds
-			processedRecordsTiming := time.Since(processRecordsStartTime) / 1000000
+			processedRecordsTiming := time.Since(processRecordsStartTime).Milliseconds()
 			sc.mService.RecordProcessRecordsTime(shard.ID, float64(processedRecordsTiming))
 		}
 

--- a/clientlibrary/worker/shard-consumer.go
+++ b/clientlibrary/worker/shard-consumer.go
@@ -208,7 +208,7 @@ func (sc *ShardConsumer) getRecords(shard *par.ShardStatus) error {
 			return err
 		}
 
-		getRecordsTime := time.Since(getRecordsStartTime).Milliseconds()
+		getRecordsTime := time.Since(getRecordsStartTime) / time.Millisecond
 		sc.mService.RecordGetRecordsTime(shard.ID, float64(getRecordsTime))
 
 		// reset the retry count after success
@@ -235,7 +235,7 @@ func (sc *ShardConsumer) getRecords(shard *par.ShardStatus) error {
 			// Delivery the events to the record processor
 			sc.recordProcessor.ProcessRecords(input)
 
-			processedRecordsTiming := time.Since(processRecordsStartTime).Milliseconds()
+			processedRecordsTiming := time.Since(processRecordsStartTime) / time.Millisecond
 			sc.mService.RecordProcessRecordsTime(shard.ID, float64(processedRecordsTiming))
 		}
 


### PR DESCRIPTION
The ecosystem around Prometheus shows a strong bias towards reporting times as floats, in seconds.

This extends to the default histogram bucket sizes[1], which are designed to capture sensible response times of a networked service *in seconds*.

The metric producer should respect this convention *or* at least sensible bucket sizes designed for milliseconds should be added to the metric definitions. As it stands, almost all observations fall in to the 10ms or +inf buckets, making the histogram useless for anything except calculating the mean from the sum/count.

I'm happy to rework the PR with explicit bucket sizes if preferred (to maintain compatibility with the existing metric).

However, from my PoV no release has yet been cut since this functionality was added, and it's largely useless in its current state, so changing to match the expectation of most Prometheus devs makes sense.

1: https://github.com/prometheus/client_golang/blob/3bb96180b64926d9c5d9e240155787e3c477dd49/prometheus/histogram.go#L63
