### PR TITLE
Add support for lease stealing

### DIFF
--- a/HyperMake
+++ b/HyperMake
@@ -8,8 +8,8 @@ targets:
   rebuild-toolchain:
     description: build toolchain image
     watches:
-      - support/docker/toolchain
-    build: support/docker/toolchain
+      - support/toolchain/docker
+    build: support/toolchain/docker
 
   toolchain:
     description: placeholder for additional toolchain dependencies

--- a/clientlibrary/checkpoint/checkpointer.go
+++ b/clientlibrary/checkpoint/checkpointer.go
@@ -40,9 +40,13 @@ const (
 	LeaseTimeoutKey   = "LeaseTimeout"
 	SequenceNumberKey = "Checkpoint"
 	ParentShardIdKey  = "ParentShardId"
+	ClaimRequestKey   = "ClaimRequest"
 
 	// We've completely processed all records in this shard.
 	ShardEnd = "SHARD_END"
+
+	// ErrShardClaimed is returned when shard is claimed
+	ErrShardClaimed = "Shard is already claimed by another node"
 )
 
 type ErrLeaseNotAcquired struct {
@@ -72,7 +76,17 @@ type Checkpointer interface {
 
 	// RemoveLeaseOwner to remove lease owner for the shard entry to make the shard available for reassignment
 	RemoveLeaseOwner(string) error
+
+	// New Lease Stealing Methods
+	// ListActiveWorkers returns active workers and their shards
+	ListActiveWorkers(map[string]*par.ShardStatus) (map[string][]*par.ShardStatus, error)
+
+	// ClaimShard claims a shard for stealing
+	ClaimShard(*par.ShardStatus, string) error
 }
 
 // ErrSequenceIDNotFound is returned by FetchCheckpoint when no SequenceID is found
 var ErrSequenceIDNotFound = errors.New("SequenceIDNotFoundForShard")
+
+// ErrShardNotAssigned is returned by ListActiveWorkers when no AssignedTo is found
+var ErrShardNotAssigned = errors.New("AssignedToNotFoundForShard")

--- a/clientlibrary/config/config.go
+++ b/clientlibrary/config/config.go
@@ -122,6 +122,18 @@ const (
 
 	// The amount of milliseconds to wait before graceful shutdown forcefully terminates.
 	DefaultShutdownGraceMillis = 5000
+
+	// Lease stealing defaults to false for backwards compatibility.
+	DefaultEnableLeaseStealing = false
+
+	// Interval between rebalance tasks defaults to 5 seconds.
+	DefaultLeaseStealingIntervalMillis = 5000
+
+	// Number of milliseconds to wait before another worker can aquire a claimed shard
+	DefaultLeaseStealingClaimTimeoutMillis = 120000
+
+	// Number of milliseconds to wait before syncing with lease table (dynamodDB)
+	DefaultLeaseSyncingIntervalMillis = 60000
 )
 
 type (
@@ -257,6 +269,18 @@ type (
 
 		// MonitoringService publishes per worker-scoped metrics.
 		MonitoringService metrics.MonitoringService
+
+		// EnableLeaseStealing turns on lease stealing
+		EnableLeaseStealing bool
+
+		// LeaseStealingIntervalMillis The number of milliseconds between rebalance tasks
+		LeaseStealingIntervalMillis int
+
+		// LeaseStealingClaimTimeoutMillis The number of milliseconds to wait before another worker can aquire a claimed shard
+		LeaseStealingClaimTimeoutMillis int
+
+		// LeaseSyncingTimeInterval The number of milliseconds to wait before syncing with lease table (dynamoDB)
+		LeaseSyncingTimeIntervalMillis int
 	}
 )
 

--- a/clientlibrary/config/config_test.go
+++ b/clientlibrary/config/config_test.go
@@ -39,8 +39,34 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, "appName", kclConfig.ApplicationName)
 	assert.Equal(t, 500, kclConfig.FailoverTimeMillis)
 	assert.Equal(t, 10, kclConfig.TaskBackoffTimeMillis)
+
 	assert.True(t, kclConfig.EnableEnhancedFanOutConsumer)
 	assert.Equal(t, "fan-out-consumer", kclConfig.EnhancedFanOutConsumerName)
+
+	assert.Equal(t, false, kclConfig.EnableLeaseStealing)
+	assert.Equal(t, 5000, kclConfig.LeaseStealingIntervalMillis)
+
+	contextLogger := kclConfig.Logger.WithFields(logger.Fields{"key1": "value1"})
+	contextLogger.Debugf("Starting with default logger")
+	contextLogger.Infof("Default logger is awesome")
+}
+
+func TestConfigLeaseStealing(t *testing.T) {
+	kclConfig := NewKinesisClientLibConfig("appName", "StreamName", "us-west-2", "workerId").
+		WithFailoverTimeMillis(500).
+		WithMaxRecords(100).
+		WithInitialPositionInStream(TRIM_HORIZON).
+		WithIdleTimeBetweenReadsInMillis(20).
+		WithCallProcessRecordsEvenForEmptyRecordList(true).
+		WithTaskBackoffTimeMillis(10).
+		WithLeaseStealing(true).
+		WithLeaseStealingIntervalMillis(10000)
+
+	assert.Equal(t, "appName", kclConfig.ApplicationName)
+	assert.Equal(t, 500, kclConfig.FailoverTimeMillis)
+	assert.Equal(t, 10, kclConfig.TaskBackoffTimeMillis)
+	assert.Equal(t, true, kclConfig.EnableLeaseStealing)
+	assert.Equal(t, 10000, kclConfig.LeaseStealingIntervalMillis)
 
 	contextLogger := kclConfig.Logger.WithFields(logger.Fields{"key1": "value1"})
 	contextLogger.Debugf("Starting with default logger")

--- a/clientlibrary/config/kcl-config.go
+++ b/clientlibrary/config/kcl-config.go
@@ -95,7 +95,11 @@ func NewKinesisClientLibConfigWithCredentials(applicationName, streamName, regio
 		InitialLeaseTableReadCapacity:                    DefaultInitialLeaseTableReadCapacity,
 		InitialLeaseTableWriteCapacity:                   DefaultInitialLeaseTableWriteCapacity,
 		SkipShardSyncAtWorkerInitializationIfLeasesExist: DefaultSkipShardSyncAtStartupIfLeasesExist,
-		Logger: logger.GetDefaultLogger(),
+		EnableLeaseStealing:                              DefaultEnableLeaseStealing,
+		LeaseStealingIntervalMillis:                      DefaultLeaseStealingIntervalMillis,
+		LeaseStealingClaimTimeoutMillis:                  DefaultLeaseStealingClaimTimeoutMillis,
+		LeaseSyncingTimeIntervalMillis:                   DefaultLeaseSyncingIntervalMillis,
+		Logger:                                           logger.GetDefaultLogger(),
 	}
 }
 
@@ -239,5 +243,20 @@ func (c *KinesisClientLibConfiguration) WithEnhancedFanOutConsumerARN(consumerAR
 	checkIsValueNotEmpty("EnhancedFanOutConsumerARN", consumerARN)
 	c.EnhancedFanOutConsumerARN = consumerARN
 	c.EnableEnhancedFanOutConsumer = true
+	return c
+}
+
+func (c *KinesisClientLibConfiguration) WithLeaseStealing(enableLeaseStealing bool) *KinesisClientLibConfiguration {
+	c.EnableLeaseStealing = enableLeaseStealing
+	return c
+}
+
+func (c *KinesisClientLibConfiguration) WithLeaseStealingIntervalMillis(leaseStealingIntervalMillis int) *KinesisClientLibConfiguration {
+	c.LeaseStealingIntervalMillis = leaseStealingIntervalMillis
+	return c
+}
+
+func (c *KinesisClientLibConfiguration) WithLeaseSyncingIntervalMillis(leaseSyncingIntervalMillis int) *KinesisClientLibConfiguration {
+	c.LeaseSyncingTimeIntervalMillis = leaseSyncingIntervalMillis
 	return c
 }

--- a/clientlibrary/partition/partition.go
+++ b/clientlibrary/partition/partition.go
@@ -30,6 +30,8 @@ package worker
 import (
 	"sync"
 	"time"
+
+	"github.com/vmware/vmware-go-kcl/clientlibrary/config"
 )
 
 type ShardStatus struct {
@@ -43,6 +45,7 @@ type ShardStatus struct {
 	StartingSequenceNumber string
 	// child shard doesn't have end sequence number
 	EndingSequenceNumber string
+	ClaimRequest         string
 }
 
 func (ss *ShardStatus) GetLeaseOwner() string {
@@ -67,4 +70,25 @@ func (ss *ShardStatus) SetCheckpoint(c string) {
 	ss.Mux.Lock()
 	defer ss.Mux.Unlock()
 	ss.Checkpoint = c
+}
+
+func (ss *ShardStatus) GetLeaseTimeout() time.Time {
+	ss.Mux.Lock()
+	defer ss.Mux.Unlock()
+	return ss.LeaseTimeout
+}
+
+func (ss *ShardStatus) SetLeaseTimeout(timeout time.Time) {
+	ss.Mux.Lock()
+	defer ss.Mux.Unlock()
+	ss.LeaseTimeout = timeout
+}
+
+func (ss *ShardStatus) IsClaimRequestExpired(kclConfig *config.KinesisClientLibConfiguration) bool {
+	if leaseTimeout := ss.GetLeaseTimeout(); leaseTimeout.IsZero() {
+		return false
+	} else {
+		return leaseTimeout.
+			Before(time.Now().UTC().Add(time.Duration(-kclConfig.LeaseStealingClaimTimeoutMillis) * time.Millisecond))
+	}
 }

--- a/clientlibrary/worker/polling-shard-consumer.go
+++ b/clientlibrary/worker/polling-shard-consumer.go
@@ -103,7 +103,7 @@ func (sc *PollingShardConsumer) getRecords() error {
 	retriedErrors := 0
 
 	for {
-		if time.Now().UTC().After(sc.shard.LeaseTimeout.Add(-time.Duration(sc.kclConfig.LeaseRefreshPeriodMillis) * time.Millisecond)) {
+		if time.Now().UTC().After(sc.shard.GetLeaseTimeout().Add(-time.Duration(sc.kclConfig.LeaseRefreshPeriodMillis) * time.Millisecond)) {
 			log.Debugf("Refreshing lease on shard: %s for worker: %s", sc.shard.ID, sc.consumerID)
 			err = sc.checkpointer.GetLease(sc.shard, sc.consumerID)
 			if err != nil {

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -68,7 +68,8 @@ type Worker struct {
 
 	rng *rand.Rand
 
-	shardStatus map[string]*par.ShardStatus
+	shardStatus          map[string]*par.ShardStatus
+	shardStealInProgress bool
 }
 
 // NewWorker constructs a Worker instance for processing Kinesis stream data.
@@ -271,7 +272,7 @@ func (w *Worker) eventLoop() {
 			log.Infof("Found %d shards", foundShards)
 		}
 
-		// Count the number of leases hold by this worker excluding the processed shard
+		// Count the number of leases held by this worker excluding the processed shard
 		counter := 0
 		for _, shard := range w.shardStatus {
 			if shard.GetLeaseOwner() == w.workerID && shard.GetCheckpoint() != chk.ShardEnd {
@@ -302,6 +303,20 @@ func (w *Worker) eventLoop() {
 					continue
 				}
 
+				var stealShard bool
+				if w.kclConfig.EnableLeaseStealing && shard.ClaimRequest != "" {
+					upcomingStealingInterval := time.Now().UTC().Add(time.Duration(w.kclConfig.LeaseStealingIntervalMillis) * time.Millisecond)
+					if shard.GetLeaseTimeout().Before(upcomingStealingInterval) && !shard.IsClaimRequestExpired(w.kclConfig) {
+						if shard.ClaimRequest == w.workerID {
+							stealShard = true
+							log.Debugf("Stealing shard: %s", shard.ID)
+						} else {
+							log.Debugf("Shard being stolen: %s", shard.ID)
+							continue
+						}
+					}
+				}
+
 				err = w.checkpointer.GetLease(shard, w.workerID)
 				if err != nil {
 					// cannot get lease on the shard
@@ -309,6 +324,11 @@ func (w *Worker) eventLoop() {
 						log.Errorf("Cannot get lease: %+v", err)
 					}
 					continue
+				}
+
+				if stealShard {
+					log.Debugf("Successfully stole shard: %+v", shard.ID)
+					w.shardStealInProgress = false
 				}
 
 				// log metrics on got lease
@@ -325,6 +345,13 @@ func (w *Worker) eventLoop() {
 			}
 		}
 
+		if w.kclConfig.EnableLeaseStealing {
+			err = w.rebalance()
+			if err != nil {
+				log.Warnf("Error in rebalance: %+v", err)
+			}
+		}
+
 		select {
 		case <-*w.stop:
 			log.Infof("Shutting down...")
@@ -333,6 +360,90 @@ func (w *Worker) eventLoop() {
 			log.Debugf("Waited %d ms to sync shards...", shardSyncSleep)
 		}
 	}
+}
+
+func (w *Worker) rebalance() error {
+	log := w.kclConfig.Logger
+
+	workers, err := w.checkpointer.ListActiveWorkers(w.shardStatus)
+	if err != nil {
+		log.Debugf("Error listing workers. workerID: %s. Error: %+v ", w.workerID, err)
+		return err
+	}
+
+	// Only attempt to steal one shard at at time, to allow for linear convergence
+	if w.shardStealInProgress {
+		shardInfo := make(map[string]bool)
+		err := w.getShardIDs("", shardInfo)
+		if err != nil {
+			return err
+		}
+		for _, shard := range w.shardStatus {
+			if shard.ClaimRequest != "" && shard.ClaimRequest == w.workerID {
+				log.Debugf("Steal in progress. workerID: %s", w.workerID)
+				return nil
+			}
+			// Our shard steal was stomped on by a Checkpoint.
+			// We could deal with that, but instead just try again
+			w.shardStealInProgress = false
+		}
+	}
+
+	var numShards int
+	for _, shards := range workers {
+		numShards += len(shards)
+	}
+
+	numWorkers := len(workers)
+
+	// 1:1 shards to workers is optimal, so we cannot possibly rebalance
+	if numWorkers >= numShards {
+		log.Debugf("Optimal shard allocation, not stealing any shards. workerID: %s, %v > %v. ", w.workerID, numWorkers, numShards)
+		return nil
+	}
+
+	currentShards, ok := workers[w.workerID]
+	var numCurrentShards int
+	if !ok {
+		numCurrentShards = 0
+		numWorkers++
+	} else {
+		numCurrentShards = len(currentShards)
+	}
+
+	optimalShards := numShards / numWorkers
+
+	// We have more than or equal optimal shards, so no rebalancing can take place
+	if numCurrentShards >= optimalShards || numCurrentShards == w.kclConfig.MaxLeasesForWorker {
+		log.Debugf("We have enough shards, not attempting to steal any. workerID: %s", w.workerID)
+		return nil
+	}
+	maxShards := int(optimalShards)
+	var workerSteal string
+	for worker, shards := range workers {
+		if worker != w.workerID && len(shards) > maxShards {
+			workerSteal = worker
+			maxShards = len(shards)
+		}
+	}
+	// Not all shards are allocated so fallback to default shard allocation mechanisms
+	if workerSteal == "" {
+		log.Infof("Not all shards are allocated, not stealing any. workerID: %s", w.workerID)
+		return nil
+	}
+
+	// Steal a random shard from the worker with the most shards
+	w.shardStealInProgress = true
+	randIndex := rand.Intn(len(workers[workerSteal]))
+	shardToSteal := workers[workerSteal][randIndex]
+	log.Debugf("Stealing shard %s from %s", shardToSteal, workerSteal)
+
+	err = w.checkpointer.ClaimShard(w.shardStatus[shardToSteal.ID], w.workerID)
+	if err != nil {
+		w.shardStealInProgress = false
+		return err
+	}
+	return nil
 }
 
 // List all shards and store them into shardStatus table

--- a/support/toolchain/docker/Dockerfile
+++ b/support/toolchain/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.13
 ENV PATH /go/bin:/src/bin:/root/go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/src
 RUN go get -v github.com/alecthomas/gometalinter && \

--- a/test/lease_stealing_util_test.go
+++ b/test/lease_stealing_util_test.go
@@ -1,0 +1,230 @@
+package test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
+	"github.com/stretchr/testify/assert"
+	chk "github.com/vmware/vmware-go-kcl/clientlibrary/checkpoint"
+	cfg "github.com/vmware/vmware-go-kcl/clientlibrary/config"
+	wk "github.com/vmware/vmware-go-kcl/clientlibrary/worker"
+)
+
+type LeaseStealingTest struct {
+	t       *testing.T
+	config  *TestClusterConfig
+	cluster *TestCluster
+	kc      kinesisiface.KinesisAPI
+	dc      dynamodbiface.DynamoDBAPI
+
+	backOffSeconds int
+	maxRetries     int
+}
+
+func NewLeaseStealingTest(t *testing.T, config *TestClusterConfig, workerFactory TestWorkerFactory) *LeaseStealingTest {
+	cluster := NewTestCluster(t, config, workerFactory)
+	clientConfig := cluster.workerFactory.CreateKCLConfig("test-client", config)
+	return &LeaseStealingTest{
+		t:              t,
+		config:         config,
+		cluster:        cluster,
+		kc:             NewKinesisClient(t, config.regionName, clientConfig.KinesisEndpoint, clientConfig.KinesisCredentials),
+		dc:             NewDynamoDBClient(t, config.regionName, clientConfig.DynamoDBEndpoint, clientConfig.KinesisCredentials),
+		backOffSeconds: 5,
+		maxRetries:     60,
+	}
+}
+
+func (lst *LeaseStealingTest) WithBackoffSeconds(backoff int) *LeaseStealingTest {
+	lst.backOffSeconds = backoff
+	return lst
+}
+
+func (lst *LeaseStealingTest) WithMaxRetries(retries int) *LeaseStealingTest {
+	lst.maxRetries = retries
+	return lst
+}
+
+func (lst *LeaseStealingTest) publishSomeData() (stop func()) {
+	done := make(chan int)
+	wg := &sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer wg.Done()
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				lst.t.Log("Coninuously publishing records")
+				publishSomeData(lst.t, lst.kc)
+			}
+		}
+	}()
+
+	return func() {
+		close(done)
+		wg.Wait()
+	}
+}
+
+func (lst *LeaseStealingTest) getShardCountByWorker() map[string]int {
+	input := &dynamodb.ScanInput{
+		TableName: aws.String(lst.config.appName),
+	}
+
+	shardsByWorker := map[string]map[string]bool{}
+	err := lst.dc.ScanPages(input, func(out *dynamodb.ScanOutput, lastPage bool) bool {
+		for _, result := range out.Items {
+			if shardID, ok := result[chk.LeaseKeyKey]; !ok {
+				continue
+			} else if assignedTo, ok := result[chk.LeaseOwnerKey]; !ok {
+				continue
+			} else {
+				if _, ok := shardsByWorker[*assignedTo.S]; !ok {
+					shardsByWorker[*assignedTo.S] = map[string]bool{}
+				}
+				shardsByWorker[*assignedTo.S][*shardID.S] = true
+			}
+		}
+		return !lastPage
+	})
+	assert.Nil(lst.t, err)
+
+	shardCountByWorker := map[string]int{}
+	for worker, shards := range shardsByWorker {
+		shardCountByWorker[worker] = len(shards)
+	}
+	return shardCountByWorker
+}
+
+type LeaseStealingAssertions struct {
+	expectedLeasesForIntialWorker int
+	expectedLeasesPerWorker       int
+}
+
+func (lst *LeaseStealingTest) Run(assertions LeaseStealingAssertions) {
+	// Publish records onto stream thoughtout the entire duration of the test
+	stop := lst.publishSomeData()
+	defer stop()
+
+	// Start worker 1
+	worker1, _ := lst.cluster.SpawnWorker()
+
+	// Wait until the above worker has all leases
+	var worker1ShardCount int
+	for i := 0; i < lst.maxRetries; i++ {
+		time.Sleep(time.Duration(lst.backOffSeconds) * time.Second)
+
+		shardCountByWorker := lst.getShardCountByWorker()
+		if shardCount, ok := shardCountByWorker[worker1]; ok && shardCount == assertions.expectedLeasesForIntialWorker {
+			worker1ShardCount = shardCount
+			break
+		}
+	}
+
+	// Assert correct number of leases
+	assert.Equal(lst.t, assertions.expectedLeasesForIntialWorker, worker1ShardCount)
+
+	// Spawn Remaining Wokers
+	for i := 0; i < lst.config.numWorkers-1; i++ {
+		lst.cluster.SpawnWorker()
+	}
+
+	// Wait For Rebalance
+	var shardCountByWorker map[string]int
+	for i := 0; i < lst.maxRetries; i++ {
+		time.Sleep(time.Duration(lst.backOffSeconds) * time.Second)
+
+		shardCountByWorker = lst.getShardCountByWorker()
+
+		correctCount := true
+		for _, count := range shardCountByWorker {
+			if count != assertions.expectedLeasesPerWorker {
+				correctCount = false
+			}
+		}
+
+		if correctCount {
+			break
+		}
+	}
+
+	// Assert Rebalanced
+	assert.Greater(lst.t, len(shardCountByWorker), 0)
+	for _, count := range shardCountByWorker {
+		assert.Equal(lst.t, assertions.expectedLeasesPerWorker, count)
+	}
+
+	// Shutdown Workers
+	time.Sleep(10 * time.Second)
+	lst.cluster.Shutdown()
+}
+
+type TestWorkerFactory interface {
+	CreateWorker(workerID string, kclConfig *cfg.KinesisClientLibConfiguration) *wk.Worker
+	CreateKCLConfig(workerID string, config *TestClusterConfig) *cfg.KinesisClientLibConfiguration
+}
+
+type TestClusterConfig struct {
+	numShards  int
+	numWorkers int
+
+	appName          string
+	streamName       string
+	regionName       string
+	workerIDTemplate string
+}
+
+type TestCluster struct {
+	t             *testing.T
+	config        *TestClusterConfig
+	workerFactory TestWorkerFactory
+	workerIDs     []string
+	workers       map[string]*wk.Worker
+}
+
+func NewTestCluster(t *testing.T, config *TestClusterConfig, workerFactory TestWorkerFactory) *TestCluster {
+	return &TestCluster{
+		t:             t,
+		config:        config,
+		workerFactory: workerFactory,
+		workerIDs:     make([]string, 0),
+		workers:       make(map[string]*wk.Worker),
+	}
+}
+
+func (tc *TestCluster) addWorker(workerID string, config *cfg.KinesisClientLibConfiguration) *wk.Worker {
+	worker := tc.workerFactory.CreateWorker(workerID, config)
+	tc.workerIDs = append(tc.workerIDs, workerID)
+	tc.workers[workerID] = worker
+	return worker
+}
+
+func (tc *TestCluster) SpawnWorker() (string, *wk.Worker) {
+	id := len(tc.workers)
+	workerID := fmt.Sprintf(tc.config.workerIDTemplate, id)
+
+	config := tc.workerFactory.CreateKCLConfig(workerID, tc.config)
+	worker := tc.addWorker(workerID, config)
+
+	err := worker.Start()
+	assert.Nil(tc.t, err)
+	return workerID, worker
+}
+
+func (tc *TestCluster) Shutdown() {
+	for workerID, worker := range tc.workers {
+		tc.t.Logf("Shutting down worker: %v", workerID)
+		worker.Shutdown()
+	}
+}

--- a/test/logger_test.go
+++ b/test/logger_test.go
@@ -23,9 +23,10 @@ package test
 import (
 	"github.com/stretchr/testify/assert"
 
+	"testing"
+
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
-	"testing"
 
 	"github.com/vmware/vmware-go-kcl/logger"
 	zaplogger "github.com/vmware/vmware-go-kcl/logger/zap"

--- a/test/record_processor_test.go
+++ b/test/record_processor_test.go
@@ -19,10 +19,11 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	kc "github.com/vmware/vmware-go-kcl/clientlibrary/interfaces"
-	"testing"
 )
 
 // Record processor factory is used to create RecordProcessor

--- a/test/worker_lease_stealing_test.go
+++ b/test/worker_lease_stealing_test.go
@@ -1,0 +1,127 @@
+package test
+
+import (
+	"testing"
+
+	chk "github.com/vmware/vmware-go-kcl/clientlibrary/checkpoint"
+	cfg "github.com/vmware/vmware-go-kcl/clientlibrary/config"
+	wk "github.com/vmware/vmware-go-kcl/clientlibrary/worker"
+	"github.com/vmware/vmware-go-kcl/logger"
+)
+
+func TestLeaseStealing(t *testing.T) {
+	config := &TestClusterConfig{
+		numShards:        4,
+		numWorkers:       2,
+		appName:          appName,
+		streamName:       streamName,
+		regionName:       regionName,
+		workerIDTemplate: workerID + "-%v",
+	}
+	test := NewLeaseStealingTest(t, config, newLeaseStealingWorkerFactory(t))
+	test.Run(LeaseStealingAssertions{
+		expectedLeasesForIntialWorker: config.numShards,
+		expectedLeasesPerWorker:       config.numShards / config.numWorkers,
+	})
+}
+
+type leaseStealingWorkerFactory struct {
+	t *testing.T
+}
+
+func newLeaseStealingWorkerFactory(t *testing.T) *leaseStealingWorkerFactory {
+	return &leaseStealingWorkerFactory{t}
+}
+
+func (wf *leaseStealingWorkerFactory) CreateKCLConfig(workerID string, config *TestClusterConfig) *cfg.KinesisClientLibConfiguration {
+	log := logger.NewLogrusLoggerWithConfig(logger.Configuration{
+		EnableConsole:     true,
+		ConsoleLevel:      logger.Error,
+		ConsoleJSONFormat: false,
+		EnableFile:        true,
+		FileLevel:         logger.Info,
+		FileJSONFormat:    true,
+		Filename:          "log.log",
+	})
+
+	log.WithFields(logger.Fields{"worker": workerID})
+
+	return cfg.NewKinesisClientLibConfig(config.appName, config.streamName, config.regionName, workerID).
+		WithInitialPositionInStream(cfg.LATEST).
+		WithMaxRecords(10).
+		WithShardSyncIntervalMillis(5000).
+		WithFailoverTimeMillis(10000).
+		WithLeaseStealing(true).
+		WithLogger(log)
+}
+
+func (wf *leaseStealingWorkerFactory) CreateWorker(workerID string, kclConfig *cfg.KinesisClientLibConfiguration) *wk.Worker {
+	worker := wk.NewWorker(recordProcessorFactory(wf.t), kclConfig)
+	return worker
+}
+
+func TestLeaseStealingInjectCheckpointer(t *testing.T) {
+	config := &TestClusterConfig{
+		numShards:        4,
+		numWorkers:       2,
+		appName:          appName,
+		streamName:       streamName,
+		regionName:       regionName,
+		workerIDTemplate: workerID + "-%v",
+	}
+	test := NewLeaseStealingTest(t, config, newleaseStealingWorkerFactoryCustomChk(t))
+	test.Run(LeaseStealingAssertions{
+		expectedLeasesForIntialWorker: config.numShards,
+		expectedLeasesPerWorker:       config.numShards / config.numWorkers,
+	})
+}
+
+type leaseStealingWorkerFactoryCustom struct {
+	*leaseStealingWorkerFactory
+}
+
+func newleaseStealingWorkerFactoryCustomChk(t *testing.T) *leaseStealingWorkerFactoryCustom {
+	return &leaseStealingWorkerFactoryCustom{
+		newLeaseStealingWorkerFactory(t),
+	}
+}
+
+func (wfc *leaseStealingWorkerFactoryCustom) CreateWorker(workerID string, kclConfig *cfg.KinesisClientLibConfiguration) *wk.Worker {
+	worker := wfc.leaseStealingWorkerFactory.CreateWorker(workerID, kclConfig)
+	checkpointer := chk.NewDynamoCheckpoint(kclConfig)
+	return worker.WithCheckpointer(checkpointer)
+}
+
+func TestLeaseStealingWithMaxLeasesForWorker(t *testing.T) {
+	config := &TestClusterConfig{
+		numShards:        4,
+		numWorkers:       2,
+		appName:          appName,
+		streamName:       streamName,
+		regionName:       regionName,
+		workerIDTemplate: workerID + "-%v",
+	}
+	test := NewLeaseStealingTest(t, config, newleaseStealingWorkerFactoryMaxLeases(t, config.numShards-1))
+	test.Run(LeaseStealingAssertions{
+		expectedLeasesForIntialWorker: config.numShards - 1,
+		expectedLeasesPerWorker:       2,
+	})
+}
+
+type leaseStealingWorkerFactoryMaxLeases struct {
+	maxLeases int
+	*leaseStealingWorkerFactory
+}
+
+func newleaseStealingWorkerFactoryMaxLeases(t *testing.T, maxLeases int) *leaseStealingWorkerFactoryMaxLeases {
+	return &leaseStealingWorkerFactoryMaxLeases{
+		maxLeases,
+		newLeaseStealingWorkerFactory(t),
+	}
+}
+
+func (wfm *leaseStealingWorkerFactoryMaxLeases) CreateKCLConfig(workerID string, config *TestClusterConfig) *cfg.KinesisClientLibConfiguration {
+	kclConfig := wfm.leaseStealingWorkerFactory.CreateKCLConfig(workerID, config)
+	kclConfig.WithMaxLeasesForWorker(wfm.maxLeases)
+	return kclConfig
+}


### PR DESCRIPTION
# Description
This PR addresses issue #4 by adding support for lease stealing. 

Lease stealing enables KCL apps to evenly distribute shards across multiple workers. Without lease stealing, shards are not guaranteed to be evenly distributed among workers. Depending on the user's architecture, this can cause issues with uneven memory utilization across workers and poses several challenges related to auto-scaling as Kinesis throughput varies throughout the day. 

To achieve lease stealing, this PR proposes a "Claim Shard" pattern borrowed from https://github.com/patrobinson/gokini. At the end of the worker's event loop, a rebalance method determines the optimal number of shards for the worker. This is calculated from number of known shards and the number of active workers. The rebalance method makes a decision to "claim a shard" based on the current number of shards the worker owns, the optimal number of shards per worker, and configured maximum number of leases for the worker. Once a shard is claimed, the lease is released by the current owner, and the worker that made the claim is eligible to acquire a lease on the claimed shard in the next iteration of the event loop.

The changes proposed in this PR are backwards compatible and users must opt-in to utilize lease stealing.