### PR TITLE
Fix data race during checkpointing

### DIFF
--- a/clientlibrary/worker/record-processor-checkpointer.go
+++ b/clientlibrary/worker/record-processor-checkpointer.go
@@ -65,6 +65,7 @@ func (pc *PreparedCheckpointer) Checkpoint() error {
 
 func (rc *RecordProcessorCheckpointer) Checkpoint(sequenceNumber *string) error {
 	rc.shard.Mux.Lock()
+	defer rc.shard.Mux.Unlock()
 
 	// checkpoint the last sequence of a closed shard
 	if sequenceNumber == nil {
@@ -73,7 +74,6 @@ func (rc *RecordProcessorCheckpointer) Checkpoint(sequenceNumber *string) error 
 		rc.shard.Checkpoint = aws.StringValue(sequenceNumber)
 	}
 
-	rc.shard.Mux.Unlock()
 	return rc.checkpoint.CheckpointSequence(rc.shard)
 }
 


### PR DESCRIPTION
Make sure the shard is locked during checkpointing.
https://github.com/vmware/vmware-go-kcl/issues/73

Signed-off-by: Tao Jiang <taoj@vmware.com>