### PR TITLE
improve log event

### DIFF
--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -292,7 +292,7 @@ func (w *Worker) eventLoop() {
 				if err != nil {
 					// checkpoint may not existed yet is not an error condition.
 					if err != chk.ErrSequenceIDNotFound {
-						log.Warnf("Couldn't fetch checkpoint: %s", err)
+						log.Warnf("Couldn't fetch checkpoint: %+v", err)
 						// move on to next shard
 						continue
 					}

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -292,7 +292,7 @@ func (w *Worker) eventLoop() {
 				if err != nil {
 					// checkpoint may not existed yet is not an error condition.
 					if err != chk.ErrSequenceIDNotFound {
-						log.Errorf(" Error: %+v", err)
+						log.Warnf("Couldn't fetch checkpoint: %s", err)
 						// move on to next shard
 						continue
 					}


### PR DESCRIPTION
Set warning log level In the worker eventloop when the checkpoint does not exist yet. This could happen in the situation in which the DynamoDB table is created but not accessible yet. In any case, the worker will try again shortly and all should be fine after some retries.